### PR TITLE
hyperlink downloads on floodgate setup page

### DIFF
--- a/_docs/floodgate/setup.md
+++ b/_docs/floodgate/setup.md
@@ -6,8 +6,8 @@ permalink: /floodgate/setup/
 
 ## Downloads:
 
-Floodgate: https://ci.opencollab.dev/job/GeyserMC/job/Floodgate/job/master/  
-Geyser: https://ci.opencollab.dev/job/GeyserMC/job/Geyser/job/master/
+Floodgate: [https://ci.opencollab.dev/job/GeyserMC/job/Floodgate/job/master/](https://ci.opencollab.dev/job/GeyserMC/job/Floodgate/job/master/)  
+Geyser: [https://ci.opencollab.dev/job/GeyserMC/job/Geyser/job/master/](https://ci.opencollab.dev/job/GeyserMC/job/Geyser/job/master/)
 
 ## Prerequisites
 


### PR DESCRIPTION
not sure if theres a cleaner way to get docsy to link links? or even do it automatically