### PR TITLE
fix #undefined dead TOC links on index page.

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -11,7 +11,7 @@ permalink: /
                     <div class="row h-100 align-items-center">
                         <div class="col-12 text-center">
                             <img class="logoimg" src="https://geysermc.org/img/geyser.png" alt="geyser logo"/>
-                            <h1 class="text-center">Revolutionize Your Minecraft Server</h1>
+                            <h2 class="text-center">Revolutionize Your Minecraft Server</h2>
                             <h4 class="text-center">Enable clients from Minecraft Bedrock Edition to join your Minecraft Java server.</h4>
                         </div>
                     </div>
@@ -22,7 +22,7 @@ permalink: /
             <div class="container">
                 <div class="row">
                     <div class="col">
-                        <h1>What is Geyser?</h1>
+                        <h2>What is Geyser?</h2>
                         <p>Geyser is a proxy, bridging the gap between Minecraft: Bedrock Edition and Minecraft: Java Edition servers. The ultimate goal of this project is to allow Minecraft: Bedrock Edition users to join Minecraft: Java Edition servers as seamlessly as possible to allow for true cross-platform.</p>
                     </div>
                     <div class="col">
@@ -38,7 +38,7 @@ permalink: /
                         <!-- <iframe src="https://www.youtube.com/embed/U7dZZ8w7Gi4" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe> -->
                     </div>
                     <div class="col">
-                        <h1>How do I use it?</h1>
+                        <h2>How do I use it?</h2>
                         <p>Geyser can be downloaded from our Jenkins server <a href="http://ci.geysermc.org">here</a> and setup installations can be found on our <a href="/geyser/setup/">wiki</a> or in the tutorial video. Geyser can be used to join any modern Java server and doesn't require anything extra to be done on their end.</p>
                     </div>
                 </div>
@@ -48,7 +48,7 @@ permalink: /
             <div class="container">
                 <div class="row">
                     <div class="col">
-                        <h1>How does it work?</h1>
+                        <h2>How does it work?</h2>
                         <p>Geyser is a middleware, which translates all the incoming and outgoing packets. With this being said, Geyser works as a standalone proxy, meaning you can use it to join <i>any</i> modern Minecraft Java server. Geyser can also be installed on your server as a plugin, so you can easily make your server compatible with Minecraft: Bedrock Edition.</p>
                     </div>
                     <div class="col">
@@ -61,7 +61,7 @@ permalink: /
             <div class="container">
                 <div class="row">
                     <div class="col">
-                        <h1>Join from anywhere</h1>
+                        <h2>Join from anywhere</h2>
                         <p>Geyser can be joined from Windows 10, iOS, Android, and even consoles
                             (see <a href="/geyser/using-geyser-with-consoles/">here</a>
                             for how to set this up!) Geyser is tested working with a


### PR DESCRIPTION
By setting head element to 2 the tittle does not get added to TOC sidebar links.
