### PR TITLE
Fix bedrock nether config typo

### DIFF
--- a/_docs/geyser/understanding-the-config.md
+++ b/_docs/geyser/understanding-the-config.md
@@ -112,7 +112,7 @@ saved-user-logins:
 
 **`add-non-bedrock-items`**: Whether to add (at this time, only) the furnace minecart as a separate item in the game, which normally does not exist in Bedrock Edition. This should only need to be disabled if using a proxy that does not use the "transfer packet" style of server switching. If this is disabled, furnace minecart items will be mapped to hopper minecart items. This option requires a restart of Geyser in order to change its setting.
 
-**`above-nether-bedrock-building`**: Bedrock prevents building and displaying blocks above Y127 in the Nether - enabling this config option works around that by changing the Nether dimension ID to the End ID. The main downside to this is that the sky will resemble that of the End sky in the Nether, but ultimately it's the only way for this feature to work.
+**`above-bedrock-nether-building`**: Bedrock prevents building and displaying blocks above Y127 in the Nether - enabling this config option works around that by changing the Nether dimension ID to the End ID. The main downside to this is that the sky will resemble that of the End sky in the Nether, but ultimately it's the only way for this feature to work.
 
 **`force-resource-packs`**: Force clients to load all resource packs if there are any. If set to false, it allows the user to disconnect from the server if they don't want to download the resource packs.
 


### PR DESCRIPTION
It's `above-bedrock-nether-building`, not `above-nether-bedrock-building`.