### PR TITLE
Adding of Netbela to the list of Hosting providers

### DIFF
--- a/_data/providers.json
+++ b/_data/providers.json
@@ -271,7 +271,7 @@
     {
       "name": "Netbela",
       "url": "https://netbela.nl/store/minecraft",
-      "description": "Install Geyser as a plugin with the dedicated Plugin installer. Use the same port as your Java server for the Bedrock address and port in your config and connect with that specific address and port."
+      "description": "Install Geyser as a plugin with the dedicated Plugin installer. Use the same port as your Java server in your config. Connect using the same address and port as your Java server."
     },
     {
       "name": "NFOservers",

--- a/_data/providers.json
+++ b/_data/providers.json
@@ -269,6 +269,11 @@
       "description": "Get Geyser as a plugin. Use the same port as your Java server for the Bedrock port in your config and connect with that port, or buy a dedicated IP address to support a different port."
     },
     {
+      "name": "Netbela",
+      "url": "https://netbela.nl/store/minecraft",
+      "description": "Install Geyser as a plugin with the dedicated Plugin installer. Use the same port as your Java server for the Bedrock address and port in your config and connect with that specific address and port."
+    },
+    {
       "name": "NFOservers",
       "url": "https://nfoservers.com/",
       "description": "Get Geyser as a plugin. Make sure your remote address and your bedrock address are your server IP in the Geyser config file. As an alternative, you can run Geyser standalone separately on an Unmanaged VDS."

--- a/_docs/geyser/supported-hosting-providers.md
+++ b/_docs/geyser/supported-hosting-providers.md
@@ -26,3 +26,4 @@ It should also be noted that these providers may not be verified by the Geyser t
 {% for provider in site.data.providers.no_support %}
 * [{{ provider.name}}]({{ provider.url }}){% if provider.description != nil or provider.description_template != nil %} - {{ site.data.providers.description_templates[provider.description_template] }} {{ provider.description }}{% endif %}
 {% endfor %}
+

--- a/_docs/geyser/supported-hosting-providers.md
+++ b/_docs/geyser/supported-hosting-providers.md
@@ -26,4 +26,3 @@ It should also be noted that these providers may not be verified by the Geyser t
 {% for provider in site.data.providers.no_support %}
 * [{{ provider.name}}]({{ provider.url }}){% if provider.description != nil or provider.description_template != nil %} - {{ site.data.providers.description_templates[provider.description_template] }} {{ provider.description }}{% endif %}
 {% endfor %}
-


### PR DESCRIPTION
Hi there,

The company Netbela (hosting company from the Netherlands) supports the use of this plugin, Could you perhaps add the following to the 'Support for Geyser' list? Link: https://netbela.nl/store/minecraft
  Name: Netbela
  Description: Install Geyser as a plugin with the dedicated Plugin installer. 
                Use the same port as your Java server for the Bedrock address and port in your config and connect with that specific address and port.