### PR TITLE
Add Minefort to the list of hosting providers

### DIFF
--- a/_data/providers.json
+++ b/_data/providers.json
@@ -49,6 +49,11 @@
       "description": "Click \"Enable Bedrock Support\" on the server dashboard and follow the steps. For manual installation: Add Destination Port 19132 with Protocol UDP to the port forward mapping and connect to the given source port."
     },
     {
+      "name": "Minefort",
+      "url": "https://minefort.com/",
+      "description": "On the server dashboard under \"Connect Support\", make sure \"Allow Bedrock\" is enabled. Then simply connect via `play.minefort.com` and join using `/server <servername>`, or connect via `<servername>.minefort.com`."
+    },
+    {
       "name": "Minehut",
       "url": "https://minehut.com/",
       "description": "Connect via `bedrock.minehut.com` and do `/join <servername>`, or connect directly via `<servername>.bedrock.minehut.gg`."


### PR DESCRIPTION
[Minefort](https://minefort.com/) is a full-featured free Minecraft server hosting. We support Geyser out of the box on every server. Users simply need to make sure it is enabled in their server dashboard.