### PR TITLE
Update Default Tydium Skin API Link + Minor Change

### DIFF
--- a/_docs/other/community-geyser-projects.md
+++ b/_docs/other/community-geyser-projects.md
@@ -126,6 +126,6 @@ Creator: [Vincss](https://github.com/vincss)
 
 ## TydiumCraft Skin API
 An API makes it easier for your Bedrock skin to be rendered and outputted!
-* [Website](https://tydiumcraft.net/docs/skinapi)
+* [Website](https://tydiumcraft.net/)
 
-Creators: [Tydium](https://github.com/Tydium), [higbead](https://github.com/higbead), [gibbon27](https://github.com/gibbon27)
+Creators: [Tydium](https://github.com/Tydium)


### PR DESCRIPTION
Considering TC doesn't have a server anymore, I have dedicated the main site to the API. Therefore "/" is now the main docs home page. I also removed the other two creators since they have both faded off the planet of earth + they don't even work with me on the project. (The main Skin API page is officially back up for anyone wondering.)