### PR TITLE
[Needs conformation] mc-host24.de

### DIFF
--- a/_data/providers.json
+++ b/_data/providers.json
@@ -257,6 +257,7 @@
       "name": "MC-HOST24.de",
       "url": "https://mc-host24.de/",
       "description_template": "default"
+      "description": "Make sure your remote address is 'auto' and your bedrock address is your server IP."
     },
     {
       "name": "Meloncube",


### PR DESCRIPTION
Looks like mc-host24.de needs you to set your Bedrock address to your server ip.