### PR TITLE
Add FREAKHOSTING as a provider

### DIFF
--- a/_data/providers.json
+++ b/_data/providers.json
@@ -198,6 +198,11 @@
       "description_template": "default"
     },
     {
+      "name": "FREAKHOSTING",
+      "url": "https://freakhosting.com/",
+      "description_template": "default"
+    },
+    {
       "name": "FreeMcServer.net",
       "url": "https://freemcserver.net",
       "description_template": "default"


### PR DESCRIPTION
Include FREAKHOSTING as a hosting option in the providers list.