### PR TITLE
Add portforwarding page, adjust providers

### DIFF
--- a/_data/providers.json
+++ b/_data/providers.json
@@ -211,7 +211,7 @@
     {
       "name": "Heavynode",
       "url": "https://www.heavynode.com/",
-      "description": "Set the Bedrock port to the Java server's port and connect with that port. To resolve further connection issues, see [here](https://wiki.geysermc.org/geyser/fixing-unable-to-connect-to-world/#bedrock-players-can-connect-after-hitting-the-server-on-a-tcp-port-eg-on-java-or-a-website-on-the-same-server-or-only-people-who-also-play-on-java-edition-can-join-from-geyser)"
+      "description": "Set the Bedrock port to the Java server's port and connect with that port. To resolve further connection issues, see [here](https://wiki.geysermc.org/geyser/portforwarding/#ovh-and-soyoustart)."
     },
     {
       "name": "Hicoria",
@@ -261,7 +261,7 @@
     {
       "name": "NiCraft",
       "url": "https://www.ni-host.com/",
-      "description": "Use the same port as your Java server for the Bedrock port in your config and connect with that port.\n  - To fix connection issues, [here](https://wiki.geysermc.org/geyser/fixing-unable-to-connect-to-world/#bedrock-players-can-connect-after-hitting-the-server-on-a-tcp-port-eg-on-java-or-a-website-on-the-same-server-or-only-people-who-also-play-on-java-edition-can-join-from-geyser).\n  - So if your players encounter this issue, please ask them to try to connect (even if they don't have Minecraft) from Java Edition first while their Bedrock client is opened, and after they should be able to join on Bedrock Edition."
+      "description": "Use the same port as your Java server for the Bedrock port in your config and connect with that port.\n  - To fix seemingly random connection issues, [here](https://wiki.geysermc.org/geyser/portforwarding/#ovh-and-soyoustart)."
     },
     {
       "name": "Nitrado",
@@ -312,12 +312,7 @@
     {
       "name": "Revivenode",
       "url": "https://revivenode.com/",
-      "description": "Set the Bedrock port to the Java server's port (either by setting it yourself, or enabling \"clone-remote-port\". Connect with the same IP and port as you would on Java. \n  - To fix random `Unable to Connect` issues, see [here](https://wiki.geysermc.org/geyser/fixing-unable-to-connect-to-world/#bedrock-players-can-connect-after-hitting-the-server-on-a-tcp-port-eg-on-java-or-a-website-on-the-same-server-or-only-people-who-also-play-on-java-edition-can-join-from-geyser).\n  - Alternatively, if your players encounter this issue, please ask them to try to connect from Java Edition first while in the same network, and after, they should be able to join on Bedrock Edition."
-    },
-    {
-      "name": "SunriseNode - TODO",
-      "url": "https://sunrisenode.com",
-      "description": "Get Geyser as a plugin. Use the same port as your Java server for the Bedrock port in your config and connect with that port."
+      "description": "Set the Bedrock port to the Java server's port (either by setting it yourself, or enabling \"clone-remote-port\". Connect with the same IP and port as you would on Java. \n  - To fix random `Unable to Connect` issues, see [here](https://wiki.geysermc.org/geyser/portforwarding/#ovh-and-soyoustart)."
     },
     {
       "name": "ScalaCube",
@@ -337,7 +332,7 @@
     {
       "name": "SoYouStart",
       "url": "https://www.soyoustart.com",
-      "description": "Please see [here](https://wiki.geysermc.org/geyser/fixing-unable-to-connect-to-world/#bedrock-players-can-connect-after-hitting-the-server-on-a-tcp-port-eg-on-java-or-a-website-on-the-same-server-or-only-people-who-also-play-on-java-edition-can-join-from-geyser) to fix Bedrock edition connections."
+      "description": "Please see [here](https://wiki.geysermc.org/geyser/portforwarding/#ovh-and-soyoustart) to fix Bedrock edition connections."
     },
     {
       "name": "Sparked Host",

--- a/_data/providers.json
+++ b/_data/providers.json
@@ -1,6 +1,9 @@
 {
   "description_templates": {
-    "default": "Get Geyser as a plugin, as in the [setup guide](https://wiki.geysermc.org/geyser/setup/). Use the same port as your Java server for the Bedrock port in your config (either by setting it yourself, or enabling \"clone-remote-port\") and connect with the same IP and port as you would on Java."
+    "default": "Enable `clone-remote-port` (or manually set `bedrock port` to the Java port), and connect with the Java IP and port.",
+    "ip_and_port": "Enable `clone-remote-port` (or manually set `bedrock port` to the Java port), uncomment `bedrock address`, and change `0.0.0.0` to your Java server's IP. Connect with the Java IP and port.",
+    "forwarding_option": "Offers a working portforwarding option.",
+    "java_ip": "Make sure your remote address is 'auto', uncomment `bedrock address`, and change `0.0.0.0` to your Java server's IP."
   },
   "built_in": [
     {
@@ -113,33 +116,27 @@
     {
       "name": "Akliz",
       "url": "https://www.akliz.net/",
-      "description": "Get Geyser as a plugin. They should have a port forwarding option that works."
+      "description_template": "forwarding_option"
     },
     {
       "name": "Aquatis",
       "url": "https://aquatis.host/",
-      "description": "Get Geyser as a plugin. Need to open a support ticket to get UDP ports and then update the config to reflect your new Bedrock port."
-    },
-    {
-      "name": "Azure",
-      "url": "https://azure.microsoft.com/",
-      "description": "Get Geyser as a plugin. Not a dedicated Minecraft service provider."
+      "description": "Need to open a support ticket to get a UDP port, then use that as the `bedrock port`."
     },
     {
       "name": "BisectHosting",
       "url": "https://www.bisecthosting.com/",
-      "description": "You must have a plan with a dedicated IP. Get Geyser as a plugin. In Geyser's config, uncomment the bedrock address field and set it to the public IP of your server (e.g. `address: 51.79.129.18`). Leave the port as `19132`. Under the home tab, select 'Enable UDP Network' and restart the server. See Bisect's [article](https://www.bisecthosting.com/clients/index.php?rp=/knowledgebase/193/How-to-install-Geyser-and-Floodgate-on-a-Minecraft-Java-server.html) for full instructions."
+      "description": "You must have a plan with a dedicated IP. In Geyser's config, uncomment the bedrock address field and set it to the public IP of your server (e.g. `address: 51.79.129.18`). Leave the port as `19132`. Under the home tab, select 'Enable UDP Network' and restart the server. See Bisect's [article](https://www.bisecthosting.com/clients/index.php?rp=/knowledgebase/193/How-to-install-Geyser-and-Floodgate-on-a-Minecraft-Java-server.html) for full instructions."
     },
     {
       "name": "Bloom.Host",
       "url": "https://www.bloom.host/",
-      "description": "Get Geyser as a plugin. They have a port forwarding option that works."
+      "description_template": "forwarding_option"
     },
     {
       "name": "Clovux",
       "url": "https://clovux.net/",
-      "description_template": "default",
-      "description": "Make sure your remote address is 'auto' and your bedrock address is your server IP."
+      "description_template": "java_ip"
     },
     {
       "name": "Consulhosting",
@@ -149,17 +146,12 @@
     {
       "name": "Craft-Hosting",
       "url": "https://craft-hosting.ru/",
-      "description": "Get Geyser as a plugin. Use the same port as your Java server for the Bedrock port in your config and connect with that port; note that this provider appears to only provide service in Russia."
+      "description": "Set the Bedrock port to the Java server's port and connect with that port; note that this provider appears to only provide service in Russia."
     },
     {
       "name": "DedicatedMC",
       "url": "https://dedicatedmc.io/",
-      "description": "Get Geyser as a plugin. Need to ask to open the default bedrock port."
-    },
-    {
-      "name": "Eendhosting",
-      "url": "https://eendhosting.nl/",
-      "description_template": "default"
+      "description": "Need to ask to open the default bedrock port."
     },
     {
       "name": "EnviroMC",
@@ -169,28 +161,27 @@
     {
       "name": "ExtraVM",
       "url": "https://extravm.com/",
-      "description_template": "default",
-      "description": "Make sure your remote address and your bedrock address is your server IP."
+      "description_template": "java_ip"
     },
     {
       "name": "FadeHost",
       "url": "https://fadehost.com/",
-      "description": "Get Geyser as a plugin. Use the same port as your Java server for the Bedrock port in your config and connect with that port or buy a dedicated IP address to support a different port."
+      "description": "Set the Bedrock port to the Java server's port and connect with that port or buy a dedicated IP address to support a different port."
     },
     {
       "name": "FakaHeda",
       "url": "https://fakaheda.eu/",
-      "description": "Get Geyser as a plugin. Use the same port as your Java server or use one of the available ports allocated for your server, for the Bedrock port in your config and connect with that port."
+      "description": "Set the Bedrock port to the Java server's port or use one of the available ports allocated for your server, for the Bedrock port in your config and connect with that port."
     },
     {
       "name": "FalixNodes",
       "url": "https://falixnodes.net/",
-      "description": "Get Geyser as a plugin. Open a port yourself on the network page in the game panel, then change the port under the bedrock section of the Geyser config."
+      "description": "Open a port yourself on the network page in the game panel, then use that port in the bedrock section of the Geyser config."
     },
     {
       "name": "Ferox Hosting",
       "url": "https://feroxhosting.nl",
-      "description": "Get Geyser as a plugin. Open a port yourself in our panel and check out the [knowledgebase](https://feroxhosting.nl/kb/) for how to install and configure the plugin."
+      "description": "Open a port yourself in their panel and check out the [knowledgebase article](https://feroxhosting.nl/kb/) for how to install and configure Geyser."
     },
     {
       "name": "Fluctis Hosting",
@@ -208,40 +199,24 @@
       "description_template": "default"
     },
     {
-      "name": "Futurehosting",
-      "url": "https://futurehosting.org/",
-      "description_template": "default",
-      "description": "Make sure your `bedrock` `address` in your Geyser config is your server IP."
-    },
-    {
       "name": "GameHosting.it",
       "url": "https://www.gamehosting.it/",
       "description_template": "default"
     },
     {
-      "name": "Google Cloud",
-      "url": "https://cloud.google.com/",
-      "description": "Not a dedicated Minecraft provider\n  - 90 day/$300 free trial\n  - \n  - Note: You'll need to also allow port 19132 on UDP, use Paper instead of vanilla, and put Geyser in the plugins folder\n  - You also don't need an SSD, they're just trying to make you pay more"
-    },
-    {
       "name": "GPortal",
       "url": "https://www.g-portal.com/",
-      "description": "Get Geyser as a plugin. Need to ask to open a UDP port. Also, make sure your `bedrock` `address` in your Geyser config is your server IP."
+      "description": "Need to ask to open a UDP port, then use that in the config. Also, make sure your `bedrock` `address` in your Geyser config is your server IP."
     },
     {
       "name": "Heavynode",
       "url": "https://www.heavynode.com/",
-      "description": "Get Geyser as a plugin. Use 0.0.0.0 as the address and open a port on the network section of the control panel. Port 19132 is only available if your server has a dedicated IP (contact support), otherwise you will need to use a random port as assigned by the control panel. For servers in Canada and the UK a support ticket is needed to also open UDP traffic for Bedrock due to the OVH game firewall, see [here](https://wiki.geysermc.org/geyser/fixing-unable-to-connect-to-world/#bedrock-players-can-connect-after-hitting-the-server-on-a-tcp-port-eg-on-java-or-a-website-on-the-same-server-or-only-people-who-also-play-on-java-edition-can-join-from-geyser)."
-    },
-    {
-      "name": "Hetzner",
-      "url": "https://hetzner.com",
-      "description": "Not a dedicated Minecraft provider."
+      "description": "Set the Bedrock port to the Java server's port and connect with that port. To resolve further connection issues, see [here](https://wiki.geysermc.org/geyser/fixing-unable-to-connect-to-world/#bedrock-players-can-connect-after-hitting-the-server-on-a-tcp-port-eg-on-java-or-a-website-on-the-same-server-or-only-people-who-also-play-on-java-edition-can-join-from-geyser)"
     },
     {
       "name": "Hicoria",
       "url": "https://hicoria.com/en/",
-      "description": "Get Geyser as a plugin. Use the one of the available ports allocated for your server, for the Bedrock port in your config and connect with that port."
+      "description": "Use the one of the available ports allocated for your server for the Bedrock port in your config and connect with that port."
     },
     {
       "name": "HostEZ",
@@ -249,24 +224,19 @@
       "description": "Geyser plugin supported with self-install or installed on request with its own port. Includes firewall tested to be compatible with Geyser."
     },
     {
-      "name": "HostValues",
-      "url": "https://hostvalues.net/",
-      "description_template": "default"
-    },
-    {
       "name": "HumbleServers",
       "url": "https://humbleservers.com/",
-      "description": "Get Geyser as a plugin. Use the same port as your Java server for the Bedrock port in your config, or one of the two extra ports, and connect with that port. If the subdomain doesn't work, use your regular numbered IP address."
+      "description": "Set the Bedrock port to the Java server's port, or to one of the two extra ports, and connect with that port. If the subdomain doesn't work, use your regular numbered IP address."
     },
     {
       "name": "MC-HOST24.de",
       "url": "https://mc-host24.de/",
-      "description": "Get Geyser as a plugin. Use the same port as your Java server for the Bedrock port in your config (either by setting it yourself, or enabling \"clone-remote-port\"). Set remote address to auto, and bedrock address to the server IP. Connect with the Java IP and port."
+      "description_template": "ip_and_port"
     },
     {
       "name": "Meloncube",
       "url": "https://www.meloncube.net/",
-      "description": "Get Geyser as a plugin. Need to ask to open a UDP port."
+      "description": "Contact the support for a UDP port to use for Geyser. Set that port as the `bedrock port`, and connect with it"
     },
     {
       "name": "MineStrator",
@@ -279,11 +249,6 @@
       "description_template": "default"
     },
     {
-      "name": "Minehub",
-      "url": "https://minehub.de/",
-      "description": "Get Geyser as a plugin. Use the same port as your Java server for the Bedrock port in your config and connect with that port, or buy a dedicated IP address to support a different port."
-    },
-    {
       "name": "Netbela",
       "url": "https://netbela.nl/store/minecraft",
       "description": "Install Geyser as a plugin with the dedicated Plugin installer. Use the same port as your Java server in your config. Connect using the same address and port as your Java server."
@@ -291,12 +256,12 @@
     {
       "name": "NFOservers",
       "url": "https://nfoservers.com/",
-      "description": "Get Geyser as a plugin. Make sure your remote address and your bedrock address are your server IP in the Geyser config file. As an alternative, you can run Geyser standalone separately on an Unmanaged VDS."
+      "description": "Set your remote address and your bedrock address to the server IP in the Geyser config file. As an alternative, you can run Geyser standalone separately on an Unmanaged VDS."
     },
     {
       "name": "NiCraft",
       "url": "https://www.ni-host.com/",
-      "description": "Use the same port as your Java server for the Bedrock port in your config and connect with that port.\n  - See [here](https://wiki.geysermc.org/geyser/fixing-unable-to-connect-to-world/#bedrock-players-can-connect-after-hitting-the-server-on-a-tcp-port-eg-on-java-or-a-website-on-the-same-server-or-only-people-who-also-play-on-java-edition-can-join-from-geyser).\n  - So if your players encounter this issue, please ask them to try to connect (even if they don't have Minecraft) from Java Edition first while their Bedrock client is opened, and after they should be able to join on Bedrock Edition."
+      "description": "Use the same port as your Java server for the Bedrock port in your config and connect with that port.\n  - To fix connection issues, [here](https://wiki.geysermc.org/geyser/fixing-unable-to-connect-to-world/#bedrock-players-can-connect-after-hitting-the-server-on-a-tcp-port-eg-on-java-or-a-website-on-the-same-server-or-only-people-who-also-play-on-java-edition-can-join-from-geyser).\n  - So if your players encounter this issue, please ask them to try to connect (even if they don't have Minecraft) from Java Edition first while their Bedrock client is opened, and after they should be able to join on Bedrock Edition."
     },
     {
       "name": "Nitrado",
@@ -306,17 +271,17 @@
     {
       "name": "Nodecraft",
       "url": "https://nodecraft.com",
-      "description": "Get Geyser as a plugin. Use the default server port and 0.0.0.0 or your server IP as the host address."
+      "description": "Use the default server port and 0.0.0.0 or your server IP as the host address."
     },
     {
       "name": "Oracle Cloud / OCI",
       "url": "https://www.oracle.com/cloud/",
-      "description": "Not a dedicated Minecraft provider\n  - 30 day/$300 free trial\n  - [Tutorial for a Minecraft server in Oracle Cloud](https://blogs.oracle.com/developers/post/how-to-set-up-and-run-a-really-powerful-free-minecraft-server-in-the-cloud)\n  - Note: You'll need to also allow port 19132 on UDP in both the security list and the firewall-cmd command, use Paper instead of vanilla, and put Geyser in the plugins folder.\n -- Note for Ubuntu users: Comment out `-A INPUT -j REJECT --reject-with icmp-host-prohibited` in `/etc/iptables/rules.v4` and run `sudo iptables-restore < /etc/iptables/rules.v4` to fix ufw."
+      "description": "[Tutorial for a Minecraft server in Oracle Cloud](https://blogs.oracle.com/developers/post/how-to-set-up-and-run-a-really-powerful-free-minecraft-server-in-the-cloud)\n  - Note: You'll need to also allow port 19132 on UDP in both the security list and the firewall-cmd command.\n -- Note for Ubuntu users: Comment out `-A INPUT -j REJECT --reject-with icmp-host-prohibited` in `/etc/iptables/rules.v4` and run `sudo iptables-restore < /etc/iptables/rules.v4` to fix ufw."
     },
     {
       "name": "OVH",
       "url": "https://www.ovh.com/",
-      "description": "See [here](https://wiki.geysermc.org/geyser/fixing-unable-to-connect-to-world/#issues-connecting-with-ovh-or-a-subsidiary)."
+      "description": "To fix firewall issues blocking UDP connections, see [here](https://wiki.geysermc.org/geyser/fixing-unable-to-connect-to-world/#issues-connecting-with-ovh-or-a-subsidiary)."
     },
     {
       "name": "Pebblehost",
@@ -332,7 +297,7 @@
     {
       "name": "PUBCS",
       "url": "https://pubcs.com",
-      "description": "Get Geyser as a plugin. Use the same port as your Java server for the Bedrock port in your config and connect with that port, or upgrade to a plan that includes dedicated IP address to support a different port."
+      "description": "Set the Bedrock port to the Java server's port and connect with that port, or upgrade to a plan that includes dedicated IP address to support a different port."
     },
     {
       "name": "RamShard",
@@ -347,32 +312,32 @@
     {
       "name": "Revivenode",
       "url": "https://revivenode.com/",
-      "description": "Get Geyser as a plugin, as in the [setup guide](https://wiki.geysermc.org/geyser/setup/). Use the same port as your Java server for the Bedrock port in your config (either by setting it yourself, or enabling \"clone-remote-port\". Connect with the same IP and port as you would on Java. \n  - See [here](https://wiki.geysermc.org/geyser/fixing-unable-to-connect-to-world/#bedrock-players-can-connect-after-hitting-the-server-on-a-tcp-port-eg-on-java-or-a-website-on-the-same-server-or-only-people-who-also-play-on-java-edition-can-join-from-geyser).\n  - So if your players encounter this issue, please ask them to try to connect (even if they don't have Minecraft) from Java Edition first while their Bedrock client is opened, and after they should be able to join on Bedrock Edition."
+      "description": "Set the Bedrock port to the Java server's port (either by setting it yourself, or enabling \"clone-remote-port\". Connect with the same IP and port as you would on Java. \n  - To fix random `Unable to Connect` issues, see [here](https://wiki.geysermc.org/geyser/fixing-unable-to-connect-to-world/#bedrock-players-can-connect-after-hitting-the-server-on-a-tcp-port-eg-on-java-or-a-website-on-the-same-server-or-only-people-who-also-play-on-java-edition-can-join-from-geyser).\n  - Alternatively, if your players encounter this issue, please ask them to try to connect from Java Edition first while in the same network, and after, they should be able to join on Bedrock Edition."
     },
     {
-      "name": "SunriseNode",
+      "name": "SunriseNode - TODO",
       "url": "https://sunrisenode.com",
       "description": "Get Geyser as a plugin. Use the same port as your Java server for the Bedrock port in your config and connect with that port."
     },
     {
       "name": "ScalaCube",
       "url": "https://scalacube.com/",
-      "description": "Get Geyser as a plugin. Use the same address and port as your Java server for the Bedrock address and port in your config and connect with that port."
+      "description_template": "ip_and_port"
     },
     {
       "name": "Shockbyte",
       "url": "https://shockbyte.com/",
-      "description": "For Plugin install: use the same address and port as your Java server for the Bedrock address and port in your config and connect with that port. For Geyser Standalone installation instructions, see [here](https://shockbyte.com/billing/knowledgebase/173/Introduction-to-GeyserMCorDragonProxy-How-GeyserMC-Works.html)."
+      "description": "Use the same address and port as your Java server for the Bedrock address and port in your config and connect with that port. For Geyser Standalone installation instructions, see [here](https://shockbyte.com/billing/knowledgebase/173/Introduction-to-GeyserMCorDragonProxy-How-GeyserMC-Works.html)."
     },
     {
       "name": "Skynode.pro",
       "url": "https://skynode.pro/",
-      "description": "Get Geyser as a plugin. Go to \"Server Details\", add a new port, and change the port in your config. Connect with that, using the address from your main port."
+      "description": "Go to \"Server Details\", add a new port, and change the port in your config. Connect with that, using the address from your main port."
     },
     {
       "name": "SoYouStart",
       "url": "https://www.soyoustart.com",
-      "description": "See [here](https://wiki.geysermc.org/geyser/fixing-unable-to-connect-to-world/#bedrock-players-can-connect-after-hitting-the-server-on-a-tcp-port-eg-on-java-or-a-website-on-the-same-server-or-only-people-who-also-play-on-java-edition-can-join-from-geyser)."
+      "description": "Please see [here](https://wiki.geysermc.org/geyser/fixing-unable-to-connect-to-world/#bedrock-players-can-connect-after-hitting-the-server-on-a-tcp-port-eg-on-java-or-a-website-on-the-same-server-or-only-people-who-also-play-on-java-edition-can-join-from-geyser) to fix Bedrock edition connections."
     },
     {
       "name": "Sparked Host",
@@ -382,27 +347,22 @@
     {
       "name": "StellaNode",
       "url": "https://stellanode.com/",
-      "description": "Get Geyser as a plugin. Open a support ticket on the billing panel to receive an additional UDP port to use for Geyser."
+      "description": "Open a support ticket on the billing panel to receive an additional UDP port for Geyser, then set that as the Bedrock port."
     },
     {
       "name": "STIPE",
       "url": "https://stipe.com.au/",
-      "description": "Get Geyser as a plugin. Use the same port as your Java server for the Bedrock port in your config and connect with that port; note that this provider only provides service in Australia."
+      "description": "Set the Bedrock port to the Java server's port and connect with that port; note that this provider only provides service in Australia."
     },
     {
       "name": "SyntexHosting",
       "url": "https://syntexhosting.com/",
-      "description": "Get Geyser as a plugin. Use the same port as your Java server for the Bedrock port in the config and connect with that port, or request a (free) additional port for your bedrock clients."
+      "description": "Set the Bedrock port to the Java server's port and connect with that port, or request a (free) additional port for your bedrock clients."
     },
     {
       "name": "The Minecraft Hosting",
       "url": "https://theminecrafthosting.com/",
-      "description": "Get Geyser as a plugin. 19132 should work as a Bedrock port, if not use the same port as your Java server for the Bedrock port in your config and connect with that port."
-    },
-    {
-      "name": "Titan Nodes",
-      "url": "https://titannodes.com/",
-      "description": "Get Geyser as a plugin. Use the default server port and 0.0.0.0 as the host address."
+      "description": "Try using 19132 as the Bedrock port, if that does not work, use the same Java server's port for the Bedrock port in your config and connect with that port."
     },
     {
       "name": "TNAHosting",
@@ -427,17 +387,17 @@
     {
       "name": "Vultam",
       "url": "https://vultam.net/",
-      "description": "Get Geyser as a plugin. Use the same port as your Java server and 0.0.0.0 as the address for Bedrock, or request an additional port. The additional port can be 19132 if you buy a dedicated IP."
+      "description": "Set the Bedrock port to the Java server's port, or request an additional port. The additional port can be 19132 if you buy a dedicated IP."
     },
     {
       "name": "WinterNode",
       "url": "https://winternode.com",
-      "description": "Get Geyser as a plugin. Use the same port as your Java server for the Bedrock port in your config and connect with that port, request an additional port, or buy a dedicated IP address."
+      "description": "Set the Bedrock port to the Java server's port and connect with that port. Alternatively, request an additional port, or buy a dedicated IP address."
     },
     {
       "name": "WitherHosting",
       "url": "https://witherhosting.com/",
-      "description": "Get Geyser as a plugin. Put the port provided by the host in your config.yml for the Java and bedrock sections, or create a port in the ports manager on the panel and use that for bedrock with the main one for Java, and you will be able to connect! Refer to the hosts [support article](https://support.witherhosting.com/en/article/how-to-install-and-use-geysermc-1xn5l6v/) for more"
+      "description": "Either use the Java server's port, or create a port in the ports manager on the panel and use that for Bedrock. Refer to the hosts [support article](https://support.witherhosting.com/en/article/how-to-install-and-use-geysermc-1xn5l6v/) for more"
     }
   ],
   "no_support": [
@@ -453,7 +413,7 @@
     {
       "name": "Feather",
       "url": "https://feathermc.com/",
-      "description": "Their proxy network doesnt support UDP therefor Geyser isn't supported"
+      "description": "Their proxy network does not support UDP. Therefor Geyser is not supported - as an alternative, set up a paper server with e.g. playit.gg instead of port forwarding."
     }
   ]
 }

--- a/_docs/floodgate/features.md
+++ b/_docs/floodgate/features.md
@@ -16,7 +16,7 @@ The permission node is `floodgate.command.fwhitelist`.
 Skins of Bedrock player should be visible to Java players on servers with Floodgate 2.0 installed.  
 If they aren't, it's most likely that the skin uploading queue has grown too large and can take a while to upload your skin.
 
-Skin uploading is also a part of the [Global Api](#what-is-the-global-api). It is responsible for converting Bedrock skins to Java skins and uploading them to Mojang servers make them show up on Java Edition.
+Skin uploading is also a part of the [Global Api](/geyser/global-api). It is responsible for converting Bedrock skins to Java skins and uploading them to Mojang servers make them show up on Java Edition.
 
 We're using MineSkin internally. MineSkin is running on accounts donated by the community. So if you want to support MineSkin and make the upload times faster, feel free to look at [this page](https://mineskin.org/account) for more info.
 

--- a/_docs/floodgate/linking.md
+++ b/_docs/floodgate/linking.md
@@ -9,7 +9,7 @@ Before we introduced Global Linking, you always had to link your Java and Bedroc
 
 Keep in mind: While having your accounts linked, you will use the Java account's location, inventory data, and achievements etc. regardless of which platform you sign in from (therefore, "synchronising" the player data). The player data from the Bedrock account will not be accessible until you unlink again. As a result, you should transfer everything (ender chest contents, items, armor) to the Java account before linking to not "lose" your Bedrock progress. If you forgot to do this, you can unlink, transfer everything over, and link again.
 
-Global Linking is part of the [Global Api](https://wiki.geysermc.org/floodgate/features/#what-is-the-global-api) and uses the GlobalLinkServer to link your account. To be able to link your account you have to do the following:
+Global Linking is part of the [Global Api](https://wiki.geysermc.org/geyser/global-api/) and uses the GlobalLinkServer to link your account. To be able to link your account you have to do the following:
 1. Join the GlobalLinkServer with both your Java and Bedrock account  
    (IP: `link.geysermc.org`, Java port: `25565`, Bedrock port: `19132`)
 2. Start the linking process by typing `/linkaccount` on your Java **or** Bedrock account

--- a/_docs/floodgate/root.md
+++ b/_docs/floodgate/root.md
@@ -11,4 +11,4 @@ This is something you install in addition to Geyser. Unlike Geyser, Floodgate ca
 ## What has Floodgate 2.0 to offer?
 Floodgate 2.0 is a rewrite of Floodgate 1.0, with various bugfixes and improvements. It also introduces new features: being able to [see Bedrock player skins on Java edition](/floodgate/features/#what-is-skin-uploading),
 being able to [use Bedrock forms](/geyser/forms/), link your account once and login on every server that has [Global Linking](/floodgate/features/#what-is-global-linking) enabled,
-and the [Global Api](/floodgate/features/#what-is-the-global-api).
+and the [Global Api](/geyser/global-api).

--- a/_docs/geyser/advanced-setup.md
+++ b/_docs/geyser/advanced-setup.md
@@ -1,0 +1,87 @@
+---
+title: Advanced Setup
+---
+
+# Portforwarding on specific setups
+
+This page contains information on how to set up Geyser when self-hosting on specific configurations, such as Docker/Pterodactyl, or on specific providers, such as OVH or OCI. 
+
+<div class="alert alert-warning" role="alert">
+	If you are using a Minecraft server hosting provider (e.g. Aternos, or Apex Hosting), you should refer to the hosting provider setup on the <a href="/geyser/setup/">setup</a> page instead.
+</div>
+
+## Windows/Linux
+These are (limited) examples of how to open a port under Windows and Linux. Additionally, you will need to portforward the port on your router.
+
+### Windows
+
+// TODO: some basic instructions on how to open a port on Windows, loopback fix, then how windows sometimes has multiple network interfaces :/
+
+### Linux
+
+// TODO: Basic examples, ufw, iptables, etc.
+
+## Using Docker/Pterodactyl
+In addition to portforwarding the port in your server's firewall (and, if applicable, your router/modem), you will need to assign the port in Docker/Pterodactyl.
+
+### Docker
+For Geyser to work under Docker (e.g. using [Itzg's Docker image](https://github.com/itzg/docker-minecraft-server)), you will need to add the Geyser port on UDP to the docker-compose file. This is done by adding the following to the `ports` section:
+
+```yaml
+ports:
+    - "25565:25565"
+    - "19132:19132/udp"
+```
+The additional `/udp` suffix is required so that the port is exposed on UDP. If you want to run the Java server and Geyser on the same port, the following would work:
+
+```yaml
+ports:
+    - "25565:25565"
+    - "25565:25565/udp"
+```
+
+Alternatively, add another port with the `-p 19132:19132/udp` flag to the docker run command.
+
+### Pterodactyl
+
+Make sure to allocate the port to the server in the Pterodactyl panel, additionally to portforwarding it. See [here](https://pterodactyl.io/community/games/minecraft.html#allocations-in-the-panel) for more information.
+![Pterodactyl port allocation](https://cdn.discordapp.com/attachments/613194762249437245/1138630494909640794/image.png)
+
+<div class="alert alert-warning" role="alert">
+    If you are not able to allocate the port in the Pterodactyl panel, you will need to contact your server host to allocate one for you or try to use an existing port allocation.
+</div>
+
+## OVH/Oracle Cloud/SoYouStart
+Some providers, such as OVH, Oracle Cloud, and SoYouStart, have a firewall that blocks UDP ports by default/in most cases.
+
+### OVH/SoYouStart
+By default, OVHs firewall requires a TCP ping to the server before allowing UDP connections. This is not possible with Geyser, so you will need to disable the firewall.
+
+**To verify/temporary work around it:** <br>
+Attempt to connect to the Bedrock IP and port through a web browser - for example, `http://test.geysermc.org:19132`. Connecting won't work, but then try connecting through Bedrock on that same device, and it should work.
+Alternatively, try connecting to the server first on Java edition, then on Bedrock with the same device.
+
+**To resolve it:** <br>
+
+OVH:
+1. Navigate to `Network interfaces`
+2. Click on the `...` button on the table for your IP -> then `...` and `Configure the GAME firewall` -> `Add rule` -> `Other protocol` (or `minecraftPocketEdition` if available)
+3. Add your Geyser port into `outgoing port`.
+
+SoYouStart:
+1. Click the IP tab.
+2. Click the gear at the right of the public IP address; select "Game mitigation".
+3. Pick "Add a rule".
+4. Select "minecraftPocketEdition" in the dropdown list and enter the target UDP ports.
+5. Save and wait a few seconds for the changes to come into effect.
+
+<div class="alert alert-warning" role="alert">
+    If you do not have access to these firewall settings, but got linked to this page anyway, please contact your server host - they are likely using OVH internally.	
+</div>
+
+### Oracle Cloud/OCI
+You'll need to allow port 19132 on UDP in both the security list and the firewall-cmd command.
+
+Additional step for Ubuntu users: 
+1. Remove/comment out `-A INPUT -j REJECT --reject-with icmp-host-prohibited` in the `/etc/iptables/rules.v4` file.
+2. Then, run `sudo iptables-restore < /etc/iptables/rules.v4` to fix ufw.

--- a/_docs/geyser/api.md
+++ b/_docs/geyser/api.md
@@ -55,7 +55,7 @@ This method will return null if the player is not a Bedrock player.
 
 `GeyserApi#sendForm(UUID, Form(Builder))`<br>
 Used to send a form to the Bedrock player with the given UUID.<br>
-Click [here](/floodgate/forms/) to get more information about Forms.
+Click [here](/geyser/forms/) to get more information about Forms.
 
 `GeyserApi#onlineConnectionsCount()`<br>
 Used to get the amount of online Bedrock players.
@@ -64,7 +64,7 @@ Used to get the amount of online Bedrock players.
 
 #### [Cumulus](https://github.com/GeyserMC/Cumulus/tree/master/src/main/java/org/geysermc/cumulus)
 While technically not directly in the Geyser API, the Cumulus library is also provided by the Geyser API. 
-It allows you to send Bedrock edition forms to players. See [Cumulus](/floodgate/forms/) for more information.
+It allows you to send Bedrock edition forms to players. See [Cumulus](/geyser/forms/) for more information.
 
 #### [Events](https://github.com/GeyserMC/Geyser/tree/master/api/src/main/java/org/geysermc/geyser/api/event)
 The event package contains all the events that Geyser fires. See [here](/geyser/events) for detailed information on how to listen to Geyser events.

--- a/_docs/geyser/common-issues.md
+++ b/_docs/geyser/common-issues.md
@@ -9,6 +9,7 @@ For Floodgate issues see: [Floodgate: Known Issues/Caveats](/floodgate/issues/).
 
 # I can't connect! (Either the server doesn't show up in the friends list or I get "Unable to connect to world")
 * If you don't use a reverse proxy such as TCPShield make sure that `enable-proxy-protocol` is set to false.
+To fix "Unable to connect to world" with no console errors, see [here](/geyser/fixing-unable-to-connect-to-world/).
 
 ## If the server doesn't show up in the friends list
 
@@ -32,8 +33,8 @@ See this link for updating to Java 16: https://paper.readthedocs.io/en/latest/ja
 ### Hosting provider will not immediately open up UDP.
 
 These steps only apply for the standalone version of Geyser.
-
-This usually has something to do on your host's end. Most commonly, it's because they do not open up ports over the UDP protocol, which is what Minecraft: Bedrock Edition uses, opposed to Minecraft: Java Edition using TCP. One way to get around this (if you're using an online host) is to shut down your server, and when asking for a server jar, select Nukkit (you won't actually be switching to Nukkit). Afterward, open up your FTP file manager and find the Nukkit jar. Then, replace this jar with the server software you're using. Upon starting up the server, it should open up ports over UDP whilst still allowing you to use the server jar you desire.
+This usually has something to do on your host's end. Most commonly, it's because they do not open up ports over the UDP protocol, which is what Minecraft: Bedrock Edition uses, opposed to Minecraft: Java Edition using TCP. 
+One way to get around this (if you're using an online host) is to shut down your server, and when asking for a server jar, select Nukkit, or any other Bedrock edition server software (you won't actually be switching to Nukkit). Afterward, open up your FTP file manager and find the Nukkit jar. Then, replace this jar with the server software you're using. Upon starting up the server, it should open up ports over UDP whilst still allowing you to use the server jar you desire.
 
 **PLEASE NOTE:** If your server automatically redownloads jars upon startup, such as with an autoupdate system, this workaround will not work. Please contact your host if this does not work for you as there is nothing we can do.
 
@@ -45,30 +46,15 @@ Sometimes this happens in poor-network environments. There is an `mtu` option in
 
 This option will most likely not help if you are getting "Unable to Connect to World" with no console logs indicating a connection.
 
-# Login Failed
-
-***If you are using a plugin version:*** in your Geyser config, set your remote address to `127.0.0.1`. If that does not work, check your startup log for a message about Docker, and use that address in the remote address
-
-### Cannot reply to EncryptionRequestPacket without profile and access token
-
-There are two causes of this message:
-
-*Floodgate issue*:
-
-This message can occur with a Floodgate setup. Usually, it means that a misconfiguration occurred, or another plugin is conflicting. If you copied the Floodgate key from its folder to the Geyser folder on the same server, this is now unnecessary and you can safely remove the Geyser copy, restart, and try again.
-
-*Server is in Online Mode while Geyser is in Offline Mode*:
-
-If you have your configuration set up like this, put simply, it won't work. If authentication for the Java server is set to online, it is expected Geyser is configured the same way. The server requires a valid Minecraft: Java Edition account, and if you aren't logging into one with Geyser, then you will be unable to join the server. If your configuration is set up properly and you're still getting this issue, it could be that your credentials are invalid.
-
 ### Connection Refused: <INSERT IP AND/OR DOMAIN>
 
-Connection Refused usually means that a Java server could not be found on that port, or the server denied access to the connection on a network level. The latter can happen with anti-DDOS plugins such as TCPShield, but otherwise ensure that the server you're trying to connect to is spelled correctly in the config, is up and is port forwarded correctly.
+Connection Refused usually means that a Java server could not be found on that port, or the server denied access to the connection on a network level. 
+The latter can happen with anti-DDOS plugins such as TCPShield, but otherwise ensure that the server you're trying to connect to is spelled correctly in the config, is up and is port forwarded correctly.
 
 If you're updating from an old build of Geyser, set your remote address to `auto` and try again.
 
 ### Floodgate Misconfiguration
-See [this page](/floodgate/issues/) for more information.
+See [this page](/floodgate/setup/) for more information.
 
 ### Missing profile key. This server requires secure profiles.
 
@@ -79,14 +65,13 @@ This is unfortunately something we have no control over, and is most likely the 
 
 # "Invalid IP address!" from Bedrock
 It's currently unknown why this happens even for valid domains. Try using the IPv4 address.
+Additionally, this can happen when trying to connect to 
 
 # Bedrock clients freeze when opening up commands for the first time
 Disable `command-suggestions` in your Geyser config. This will stop the freezing at the expense of removing command suggestions from Bedrock clients.
-If you're a dedicated server admin, you can have a list of commands players should be using. This will remove any unnecessary commands from tab completion as well for Java players. It has other benefits too. Here's a plugin that can just do that: 
-[CommandWhitelist](https://www.spigotmc.org/resources/81326/)
-
-# BungeeCord freezes and crashes after bedrock player joins
-Make sure you have set `ip-forward` to `true` in your BungeeCord `config.yml` and set `bungeecord` to `true` in each connected server's `spigot.yml`.
+If you're a dedicated server admin, you can have a list of commands players should be using. This will remove any unnecessary commands from tab completion as well for Java players. 
+It has other benefits too. Here's a plugin that can just do that: 
+[CommandWhitelist](https://www.spigotmc.org/resources/81326/). Alternatively, use the [HideCommands](https://github.com/Redned235/HideCommands) Geyser extension to hide commands just for Bedrock players.
 
 # Failed to load locale asset cache: Unrecognized token 'Cannot'
 This or anything else related to failing to download a locale file on startup is usually caused by java trying to connect using IPv6 and Mojang only use IPv4, so start Geyser or the server up with this flag `-Djava.net.preferIPv4Stack=true`, EG: `java -Xms1024M -Djava.net.preferIPv4Stack=true -jar Geyser.jar`

--- a/_docs/geyser/common-issues.md
+++ b/_docs/geyser/common-issues.md
@@ -48,6 +48,22 @@ Sometimes this happens in poor-network environments. There is an `mtu` option in
 
 This option will most likely not help if you are getting "Unable to Connect to World" with no console logs indicating a connection.
 
+# Login Failed
+
+***If you are using a plugin version:*** in your Geyser config, set your remote address to `127.0.0.1`. If that does not work, check your startup log for a message about Docker, and use that address in the remote address
+
+### Cannot reply to EncryptionRequestPacket without profile and access token
+
+There are two causes of this message:
+
+*Floodgate issue*:
+
+This message can occur with a Floodgate setup. Usually, it means that a misconfiguration occurred, or another plugin is conflicting. If you copied the Floodgate key from its folder to the Geyser folder on the same server, this is now unnecessary and you can safely remove the Geyser copy, restart, and try again.
+
+*Server is in Online Mode while Geyser is in Offline Mode*:
+
+If you have your configuration set up like this, put simply, it won't work. If authentication for the Java server is set to online, it is expected Geyser is configured the same way. The server requires a valid Minecraft: Java Edition account, and if you aren't logging into one with Geyser, then you will be unable to join the server. If your configuration is set up properly and you're still getting this issue, it could be that your credentials are invalid.
+
 ### Connection Refused: <INSERT IP AND/OR DOMAIN>
 
 Connection Refused usually means that a Java server could not be found on that port, or the server denied access to the connection on a network level. 

--- a/_docs/geyser/common-issues.md
+++ b/_docs/geyser/common-issues.md
@@ -2,7 +2,9 @@
 title: Common Issues
 ---
 
-Commonly, people may have issues with Geyser not showing up in their server list or run into similar issues. This page contains a few common issues people may encounter that you might have as well as potential fixes for them. If you still can't make it work, join [our Discord](https://discord.gg/geysermc) for support.
+Commonly, people may have issues with Geyser not showing up in their server list or run into similar issues. 
+This page contains a few common issues people may encounter that you might have as well as potential fixes for them. 
+If you still can't make it work, join [our Discord](https://discord.gg/geysermc) for support.
 
 # Floodgate
 For Floodgate issues see: [Floodgate: Known Issues/Caveats](/floodgate/issues/).
@@ -64,8 +66,8 @@ See [this page](/geyser/secure-chat/).
 This is unfortunately something we have no control over, and is most likely the case when you're running Geyser as a plugin on a server host or joining a friend far away from your location. If you're running Geyser locally, this should not happen to you, but what we recommend for servers is a plugin we make called [Floodgate](https://github.com/GeyserMC/Floodgate), which allows for Bedrock clients to join your server without needing a Java Edition account. Take a look [here](Floodgate) for more information.
 
 # "Invalid IP address!" from Bedrock
-It's currently unknown why this happens even for valid domains. Try using the IPv4 address.
-Additionally, this can happen when trying to connect to 
+This can happen if the domain you are entering resolves to a SRV record, which Bedrock does not support. Try using the IPv4 address instead.
+Additionally, this can happen when trying to specify both the ip and port in the ip tab - in which case, see [here](https://cdn.discordapp.com/attachments/914971721612808222/1139316467054170253/image.png) for how to properly connect to "test.geysermc.org:19132".
 
 # Bedrock clients freeze when opening up commands for the first time
 Disable `command-suggestions` in your Geyser config. This will stop the freezing at the expense of removing command suggestions from Bedrock clients.
@@ -104,5 +106,6 @@ And so on.
 * Please also make sure that you have the same `key.pem` and `config.yml` on all of your servers.
 
 If your players can't connect from the lobby to another backend server, check console.
+
 ### Plugins that can cause issues
 * `HamsterAPI`

--- a/_docs/geyser/fixing-unable-to-connect-to-world.md
+++ b/_docs/geyser/fixing-unable-to-connect-to-world.md
@@ -2,90 +2,92 @@
 title: Fixing 'Unable to Connect to World'
 ---
 
-*Unable to Connect to World* is by far the most common error people get when attempting to set up Geyser. Here's some steps on how to solve that.
+# Fixing 'Unable to Connect to World' errors
+This is by far the most common error people get when attempting to set up Geyser. Here's some steps on how to solve it.
+Usually, this error is caused by improper configuration of Geyser, or issues with your network.
 
-**_If you are using a hosting provider: Many providers and remote hostings have additional steps you have to perform in order to be supported; see [Supporting Hosting Providers](https://wiki.geysermc.org/geyser/supported-hosting-providers/). If you're self-hosting from home, you don't need to worry about this._**
+<div class="alert alert-warning" role="alert">
+	If you are using a Minecraft server hosting provider (e.g. Aternos, or Apex Hosting), you should refer to the hosting provider setup instructions on 
+the <a href="/geyser/setup/">setup</a> page. Following these will most likely resolve the issue!
+</div>
 
-# Before we start...
+If you are not using a Minecraft server hosting provider, carry on.
 
-## ...Java players can't connect either!
+<div class="alert alert-info" role="alert">
+	To check if your server is (theoretically) reachable on Bedrock edition, try running the following command in your server console:
+    <code>geyser connectiontest &lt;ip&gt;:&lt;port&gt;</code>, and see what it suggests to try.
+</div>
 
-This **should not be** a Geyser problem. Geyser does not modify server behavior. Floodgate does modify the login structure but only for Bedrock players. Contact your hosting provider or look elsewhere for fixing this connection issue.
+### Java Edition players can't connect!
 
-## ...I just updated, and now it doesn't work!
+This **should not be** a Geyser problem. Geyser does not modify server behavior. Floodgate does modify the login structure, but only for Bedrock players. 
+Contact your hosting provider or look elsewhere for fixing this connection issue.
 
-If this occurred after updating a plugin version of Geyser, ensure that you shut off your server, swapped the Geyser jar, and then started up your server.
+### Connecting fails after updating Geyser
 
-## ...There are errors in my console!
+If this occurred after updating a plugin version of Geyser, ensure that you shut off your server, swapped the Geyser jar, and then started up your server. 
+Incase you reset your configuration file, check out the [setup guide](/geyser/setup/) again.
+
+### There are errors in my console!
 
 Please read through the [common issues page](https://wiki.geysermc.org/geyser/common-issues/). If there is another error not documented there, join us on our [Discord](https://discord.geysermc.org).
 
-## ...Have you tried restarting?
+### Try restarting the server, and the game
 
 Especially on mobile devices, sometimes just restarting Minecraft fixes the issue.
 
-# Is it the server or the client?
+### Is it the server or the client?
 
-Run your Java server IP and Bedrock address here: https://mcsrvstat.us/. It's a great way of determining if the server is reachable in the first place.
+Run your Java server IP and Bedrock address here: https://mcsrvstat.us/. It's a great way of determining if the server is reachable in the first place. 
+Additionally, check if you can see a connection attempt in the server console. If you can't, it's likely a network issue.
+
+For console players specifically: If only they can't join, while other Bedrock players can, it is likely an issue with their console connecting method.
 
 # General troubleshooting steps
 
-## Ensure you're connecting on the right IP
+### Ensure you're connecting on the right IP and Port
 
-You should be connecting with the Java server IP and the Bedrock port. If you port forwarded 19132, for example, you should specify port 19132 when connecting from Bedrock.
+You should be connecting with the Java server IP and the Bedrock port (set in the Geyser config). If you port forwarded 19132, for example, you should specify port 19132 when connecting from Bedrock.
 
-## I'm using a hosting provider or VPS!
+### I'm using a hosting provider or VPS!
 
 Please read [this page on supported hosting providers](https://wiki.geysermc.org/geyser/supported-hosting-providers/) to see if there are extra configuration steps required for your hosting or server provider.
+Some VPS/KVM providers may require further setup, such as OVH, SoYouStart, and Oracle Cloud. Please read this [note](/geyser/portforwarding/#issues-with-specific-vpskvm-providers) for more information.
 
-## Port forwarding
+### Issues using Docker or Pterodactyl
+Make sure you assign the port to pterodactyl, and on docker, to the docker compose file. See our [portforwarding](/geyser/portforwarding/#using-docker-or-pterodactyl) page for fixes.
 
-Your server does need to be port forwarded. Generally, you can follow any Minecraft: Java Edition port forwarding guide; however, you need to replace any mention of TCP with UDP and, by default, any mention of 25565 with 19132.
+# Port forwarding issues
 
-## Using TCP in DNS options/port forwarding Instead of UDP
+Your server does need to be port forwarded to allow connections from outside the local network. See [our portforwarding guide](/geyser/portforwarding/) for more information.
+
+### Using TCP in DNS options/port forwarding Instead of UDP
 
 Minecraft: Java Edition uses TCP for connecting; Minecraft: Bedrock Edition uses UDP. Port forwarding your Bedrock Edition port with only TCP will not work, it has to be UDP. Forwarding your Bedrock Edition port with `TCP/UDP` (both protocols) should also work but is not recommended unless Java Edition and Bedrock Edition is sharing the same port.
 
-## Bedrock port is less than 10000
+### Bedrock port is less than 10000
 
 Historically, having a Bedrock port that is a lower number will cause issues. Setting it to 10000 or above seems safe.
 
-## Bedrock players can connect *after* hitting the server on a TCP port (e.g. on Java or a website on the same server), OR only people who also play on Java Edition can join from Geyser
+### Bedrock players can connect *after* hitting the server on a TCP port (e.g. on Java or a website on the same server), OR only people who also play on Java Edition can join from Geyser
 
 This is likely a firewall issue on your server. Try the following workaround:
-
 Attempt to connect to the Bedrock IP and port through a web browser - for example, `http://test.geysermc.org:19132`. It won't work, but then try connecting through Bedrock, and it should work.
 
-Specific host fixes:
+Specific host fixes for OVH/SoYouStart can be found on the [portforwarding](/geyser/portforwarding/) page.
 
-SoYouStart (a subsidiary of OVH):
+### Changing the `bedrock` `address` in the Geyser config.
 
-In the SoYouStart control panel:
-1. Click the IP tab.
-2. Click the gear at the right of the public IP address; select "Game mitigation".
-3. Pick "Add a rule".
-4. Select "minecraftPocketEdition" in the dropdown list and enter the target UDP ports.
-5. Save and wait a few seconds for the changes to come into effect.
-
-## Issues connecting with OVH or a subsidiary
-
-If you're running into issues with some Bedrock players being unable to connect on OVH, navigate through the following settings:
-
-- Navigate to `Network interfaces` 
-- Click on the `...` button on the table for your IP -> then `...` and `Configure the GAME firewall` -> `Add rule` -> `Other protocol` (or `minecraftPocketEdition` if available)
-- Add your Geyser port into `outgoing port`
-
-## Changing the `bedrock` `address` in the Geyser config.
-
-Except for a few specific hosting providers, you generally do not need to change this part of the Geyser config. However, in rare instances, it does fix issues
+Except for a few specific hosting providers, you generally do not need to change this part of the Geyser config. 
+However, in rare instances, it does fix issues - for example, when Windows has multiple network adapters, it can help to set the `address` to the IP of the adapter you want to use.
 
 # Using a hosting provider or other location
 
-## Pterodactyl
+### Pterodactyl
 
 If you get this error while using the Pterodactyl Panel, try editing the Geyser config and changing the port to something besides `19132` (e.g. `25566`).
 
-## Hosting Geyser on another computer on the same network
+### Hosting Geyser on another computer on the same network
 
 ### Can only connect from the same computer and not anywhere else
 
@@ -97,7 +99,7 @@ Minecraft offers a vanilla Bedrock server [here](https://www.minecraft.net/en-us
 
 # Using Geyser on the same computer
 
-## Windows 10/11
+### Windows 10/11
 
 _This only affects people trying to join Geyser from Windows 10/11 Edition with Geyser hosted on the same computer._
 

--- a/_docs/geyser/fixing-unable-to-connect-to-world.md
+++ b/_docs/geyser/fixing-unable-to-connect-to-world.md
@@ -32,7 +32,7 @@ Incase you reset your configuration file, check out the [setup guide](/geyser/se
 
 Please read through the [common issues page](https://wiki.geysermc.org/geyser/common-issues/). If there is another error not documented there, join us on our [Discord](https://discord.geysermc.org).
 
-### Try restarting the server, and the game
+### Try restarting the server and game
 
 Especially on mobile devices, sometimes just restarting Minecraft fixes the issue.
 
@@ -52,7 +52,7 @@ You should be connecting with the Java server IP and the Bedrock port (set in th
 ### I'm using a hosting provider or VPS!
 
 Please read [this page on supported hosting providers](https://wiki.geysermc.org/geyser/supported-hosting-providers/) to see if there are extra configuration steps required for your hosting or server provider.
-Some VPS/KVM providers may require further setup, such as OVH, SoYouStart, and Oracle Cloud. Please read this [note](/geyser/portforwarding/#issues-with-specific-vpskvm-providers) for more information.
+Some VPS/KVM providers require further setup, such as OVH, SoYouStart, and Oracle Cloud. Please read this [note](/geyser/portforwarding/#issues-with-specific-vpskvm-providers) for more information.
 
 ### Issues using Docker or Pterodactyl
 Make sure you assign the port to pterodactyl, and on docker, to the docker compose file. See our [portforwarding](/geyser/portforwarding/#using-docker-or-pterodactyl) page for fixes.
@@ -61,7 +61,7 @@ Make sure you assign the port to pterodactyl, and on docker, to the docker compo
 
 Your server does need to be port forwarded to allow connections from outside the local network. See [our portforwarding guide](/geyser/portforwarding/) for more information.
 
-### Using TCP in DNS options/port forwarding Instead of UDP
+### Using TCP in DNS options/port forwarding instead of UDP
 
 Minecraft: Java Edition uses TCP for connecting; Minecraft: Bedrock Edition uses UDP. Port forwarding your Bedrock Edition port with only TCP will not work, it has to be UDP. Forwarding your Bedrock Edition port with `TCP/UDP` (both protocols) should also work but is not recommended unless Java Edition and Bedrock Edition is sharing the same port.
 
@@ -74,12 +74,13 @@ Historically, having a Bedrock port that is a lower number will cause issues. Se
 This is likely a firewall issue on your server. Try the following workaround:
 Attempt to connect to the Bedrock IP and port through a web browser - for example, `http://test.geysermc.org:19132`. It won't work, but then try connecting through Bedrock, and it should work.
 
-Specific host fixes for OVH/SoYouStart can be found on the [portforwarding](/geyser/portforwarding/) page.
+Specific host fixes for OVH/SoYouStart can be found [here](/geyser/portforwarding/#issues-with-specific-vpskvm-providers).
 
 ### Changing the `bedrock` `address` in the Geyser config.
 
 Except for a few specific hosting providers, you generally do not need to change this part of the Geyser config. 
-However, in rare instances, it does fix issues - for example, when Windows has multiple network adapters, it can help to set the `address` to the IP of the adapter you want to use.
+However, in rare instances, it does fix issues - for example, when Windows has multiple network adapters (check by running `ipconfig` in cmd), 
+it can help to set the `address` to the local IP of the adapter you want to use.
 
 # Using a hosting provider or other location
 
@@ -87,7 +88,7 @@ However, in rare instances, it does fix issues - for example, when Windows has m
 
 If you get this error while using the Pterodactyl Panel, try editing the Geyser config and changing the port to something besides `19132` (e.g. `25566`).
 
-### Hosting Geyser on another computer on the same network
+# Hosting Geyser on another computer on the same network
 
 ### Can only connect from the same computer and not anywhere else
 

--- a/_docs/geyser/geyser-command-line-arguments-and-system-properties.md
+++ b/_docs/geyser/geyser-command-line-arguments-and-system-properties.md
@@ -30,21 +30,24 @@ You may disable some warnings that may be printed to the console by using the fo
     Warning: Disabling Geyser warnings from being logged will not fix the real issue! Only disable them if you know what you are doing. 
 </div>
 
-- ```-DGeyser.PrintSecureChatInformation=true```
+- `-DGeyser.PrintSecureChatInformation=true`
   - Allows you to disable the warning about secure chat being disabled. 
   Since the warning is sent when the server sends the warning, this option does not do much anymore.
-- ```-DGeyser.ShowScoreboardLogs=true```
+- `-DGeyser.ShowScoreboardLogs=true`
   - Allows you to disable warnings related to scoreboards, such as "Tried to update score without the existence of its requested objective".
-- ```-DGeyser.ShowResourcePackLengthWarning=true```
+- `-DGeyser.ShowResourcePackLengthWarning=true`
   - Allows you to disable the warning about a resource pack having too long paths. Disabling this warning will not fix the underlying issue! 
   Console players might not be able to join your server at all if you have a resource pack with paths exceeding the 80 character limit.
-- ```-DGeyser.PrintPingsInDebugMode=true```
+- `-DGeyser.PrintPingsInDebugMode=true`
   - Controls if pings are being logged in debug mode.
-- ```-DGeyser.UseDirectAdapters=true```
+- `-DGeyser.UseDirectAdapters=true`
   - Allows you to disable the usage of NMS adapters. Disabling will result in a performance penalty and should only be used for debugging.
   This is Spigot-only and will not work on other platforms.
-- ```-DGeyser.BedrockNetworkThreads=8```
+- `-DGeyser.BedrockNetworkThreads=8`
   - Allows you to set the number of threads used for the Bedrock networking. This is not set to a specific number by default, but is instead calculated based on the available resources.
+- `-DGeyser.AddTeamSuggestions=true`
+  - Allows you to turn off suggestions for teams in the scoreboard command. This is enabled by default, disabling this can help with performance if there are a lot of teams defined. 
+  Setting "command-suggestions" to false in the config will also disable this.
 
 ## Geyser-Standalone specific options:
 

--- a/_docs/geyser/global-api.md
+++ b/_docs/geyser/global-api.md
@@ -19,5 +19,5 @@ Here are a few examples of how you could use the Global API. <br>
 [GeyserDiscordBot](https://github.com/GeyserMC/GeyserDiscordBot/blob/master/src/main/java/org/geysermc/discordbot/commands/FloodgateUuidCommand.java) 
 - GeyserMC's discord bot has a /uuid command to get a floodgate uuid from a bedrock username. <br>
 
-[FabricGeyserPlayerHeads](https://github.com/onebeastchris/customplayerheads/blob/master/src/main/java/net/onebeastofchris/customplayerheads/utils/PlayerUtils.java#L54-L72)
+[CustomPlayerHeads](https://github.com/onebeastchris/customplayerheads/blob/master/src/main/java/net/onebeastofchris/customplayerheads/utils/PlayerUtils.java#L54-L72)
 - A fabric mod that uses the Global API to get a Bedrock player's skin, and then uses that to create a player head.

--- a/_docs/geyser/portforwarding.md
+++ b/_docs/geyser/portforwarding.md
@@ -2,9 +2,10 @@
 title: Advanced Setup
 ---
 
-# Portforwarding on specific setups
+# Portforwarding
 
-This page contains information on how to set up Geyser when self-hosting on specific configurations, such as Docker/Pterodactyl, or on specific providers, such as OVH or OCI. 
+This page contains information on how to set up portforwarding required for Geyser to work when self-hosting.
+There are also guides for specific configurations, such as Docker/Pterodactyl, or on specific VPS/KVM providers, such as OVH or Oracle Cloud. 
 
 <div class="alert alert-warning" role="alert">
 	If you are using a Minecraft server hosting provider (e.g. Aternos, or Apex Hosting), you should refer to the hosting provider setup on the <a href="/geyser/setup/">setup</a> page instead.
@@ -18,11 +19,34 @@ These are (limited) examples of how to open a port under Windows and Linux. Addi
 // TODO: some basic instructions on how to open a port on Windows, loopback fix, then how windows sometimes has multiple network interfaces :/
 
 ### Linux
+Different Linux distributions, even different VPS providers ship and configure different firewalls. In the following examples, we will use `19132` as the port to open, but you should replace this with the port you are using for Geyser.
 
-// TODO: Basic examples, ufw, iptables, etc.
+- `ufw` is a simple firewall front-end for iptables that is commonly used on Ubuntu and Debian. To open a port on UDP, run the following command: <br>
+`sudo ufw allow 19132/udp` <br>
+Then, reload the firewall with `sudo ufw reload`, and see all open rules with `sudo ufw status`. <br>
+Further helpful guides: [DigitalOcean](https://www.digitalocean.com/community/tutorials/how-to-setup-a-firewall-with-ufw-on-an-ubuntu-and-debian-cloud-server), [Baeldung](https://www.baeldung.com/linux/uncomplicated-firewall)
+
+- `iptables` is a common firewall that is used on many Linux distributions. To open a port on UDP, run the following command: <br>
+`sudo iptables -A INPUT -p udp --dport 19132 -j ACCEPT` <br>
+Then, save the firewall with `sudo iptables-save`, and see all open rules with `sudo iptables -L`. <br>
+Further helpful guides for iptables: [DigitalOcean](https://www.digitalocean.com/community/tutorials/how-to-set-up-a-firewall-using-iptables-on-ubuntu-14-04), [Ubuntu](https://help.ubuntu.com/community/IptablesHowTo)
+
+- `firewalld` Add a port on UDP by running <br>
+`sudo firewall-cmd --zone=public --permanent --add-port=19132/udp` <br>
+Then, reload the firewall with `sudo firewall-cmd --reload`, and see all open rules with `sudo firewall-cmd --list-all`. <br>
+Further helpful guides: [DigitalOcean](https://www.digitalocean.com/community/tutorials/how-to-set-up-a-firewall-using-firewalld-on-centos-7)
 
 ## Using Docker/Pterodactyl
 In addition to portforwarding the port in your server's firewall (and, if applicable, your router/modem), you will need to assign the port in Docker/Pterodactyl.
+
+### Pterodactyl
+
+Make sure to allocate the port to the server in the Pterodactyl panel, additionally to portforwarding it. See [here](https://pterodactyl.io/community/games/minecraft.html#allocations-in-the-panel) for more information.
+![Pterodactyl port allocation](https://cdn.discordapp.com/attachments/613194762249437245/1138630494909640794/image.png)
+
+<div class="alert alert-warning" role="alert">
+    If you are not able to allocate the port in the Pterodactyl panel, you will need to contact your server host to allocate one for you or try to use an existing port allocation.
+</div>
 
 ### Docker
 For Geyser to work under Docker (e.g. using [Itzg's Docker image](https://github.com/itzg/docker-minecraft-server)), you will need to add the Geyser port on UDP to the docker-compose file. This is done by adding the following to the `ports` section:
@@ -41,15 +65,6 @@ ports:
 ```
 
 Alternatively, add another port with the `-p 19132:19132/udp` flag to the docker run command.
-
-### Pterodactyl
-
-Make sure to allocate the port to the server in the Pterodactyl panel, additionally to portforwarding it. See [here](https://pterodactyl.io/community/games/minecraft.html#allocations-in-the-panel) for more information.
-![Pterodactyl port allocation](https://cdn.discordapp.com/attachments/613194762249437245/1138630494909640794/image.png)
-
-<div class="alert alert-warning" role="alert">
-    If you are not able to allocate the port in the Pterodactyl panel, you will need to contact your server host to allocate one for you or try to use an existing port allocation.
-</div>
 
 ## OVH/Oracle Cloud/SoYouStart
 Some providers, such as OVH, Oracle Cloud, and SoYouStart, have a firewall that blocks UDP ports by default/in most cases.

--- a/_docs/geyser/portforwarding.md
+++ b/_docs/geyser/portforwarding.md
@@ -3,7 +3,6 @@ title: Advanced Setup
 ---
 
 # Portforwarding
-
 This page contains information on how to set up portforwarding required for Geyser to work when self-hosting.
 There are also guides for specific configurations, such as Docker/Pterodactyl, or on specific VPS/KVM providers, such as OVH or Oracle Cloud. 
 
@@ -11,12 +10,33 @@ There are also guides for specific configurations, such as Docker/Pterodactyl, o
 	If you are using a Minecraft server hosting provider (e.g. Aternos, or Apex Hosting), you should refer to the hosting provider setup on the <a href="/geyser/setup/">setup</a> page instead.
 </div>
 
-## Windows/Linux
+## Portforwarding on Linux/Windows
 These are (limited) examples of how to open a port under Windows and Linux. Additionally, you will need to portforward the port on your router.
+Additionally, if you do not have a static IP address, your IP address may change over time. 
+
+<div class="alert alert-info" role="alert">
+	Some ISPs (Internet Service Providers) block certain ports, or don't allow you to open ports (e.g. by using CGNAT, which doesn't allow you to open a port with a dynamic IP).
+Other ISPs may require you to pay extra for a static IP address. <br>
+As an alternative to portforwarding, you could use <a href="/geyser/playit-gg/">playit.gg</a> to create a tunnel.
+</div>
 
 ### Windows
+To open a port on Windows, you will need to open the port in the Windows Firewall. There are multiple ways to do this:
 
-// TODO: some basic instructions on how to open a port on Windows, loopback fix, then how windows sometimes has multiple network interfaces :/
+**Powershell** <br>
+To open a port on UDP (in our example, port 19132), run the following command in an administrator Powershell: <br>
+`New-NetFirewallRule -DisplayName "Geyser" -Direction Inbound -Protocol UDP -LocalPort 19132 -Action Allow` <br>
+After running this command, a rule named "Geyser" was created to allow UDP traffic on port 19132. <br>
+
+**Windows Defender Firewall with Advanced Security** <br>
+1. Search for "Windows Defender Firewall with Advanced Security" in the start menu, and open it. [Image](https://cdn.discordapp.com/attachments/613194762249437245/1139289055612370964/image.png)
+2. Click on "Inbound Rules" in the left sidebar. [Image](https://cdn.discordapp.com/attachments/613194762249437245/1139291934930772049/image.png)
+3. Click on "New Rule..." in the right sidebar. [Image](https://cdn.discordapp.com/attachments/613194762249437245/1139291934930772049/image.png)
+4. Select "Port" as the rule type and click "Next". [Image](https://cdn.discordapp.com/attachments/613194762249437245/1139292384283349092/image.png)
+5. Select "UDP" and "Specific local ports", and enter the port you want to open (in our example, 19132). Click "Next". [Example](https://cdn.discordapp.com/attachments/613194762249437245/1139292567410843658/image.png)
+6. Select "Allow the connection" and click "Next". [Image](https://cdn.discordapp.com/attachments/1029700125636960356/1139292899805249586/image.png)
+7. Select the profiles you want to apply the rule to (e.g. "Domain", "Private", "Public"), and click "Next". [Example](https://cdn.discordapp.com/attachments/1029700125636960356/1139292899536805949/image.png)
+8. Enter a name for the rule (e.g. "Geyser"), and click "Finish". [Image](https://cdn.discordapp.com/attachments/1029700125636960356/1139292899192881202/image.png)
 
 ### Linux
 Different Linux distributions, even different VPS providers ship and configure different firewalls. In the following examples, we will use `19132` as the port to open, but you should replace this with the port you are using for Geyser.
@@ -26,23 +46,23 @@ Different Linux distributions, even different VPS providers ship and configure d
 Then, reload the firewall with `sudo ufw reload`, and see all open rules with `sudo ufw status`. <br>
 Further helpful guides: [DigitalOcean](https://www.digitalocean.com/community/tutorials/how-to-setup-a-firewall-with-ufw-on-an-ubuntu-and-debian-cloud-server), [Baeldung](https://www.baeldung.com/linux/uncomplicated-firewall)
 
+- `firewalld` Add a port on UDP by running <br>
+  `sudo firewall-cmd --zone=public --permanent --add-port=19132/udp` <br>
+  Then, reload the firewall with `sudo firewall-cmd --reload`, and see all open rules with `sudo firewall-cmd --list-all`. <br>
+  Further helpful guides: [DigitalOcean](https://www.digitalocean.com/community/tutorials/how-to-set-up-a-firewall-using-firewalld-on-centos-7)
+
 - `iptables` is a common firewall that is used on many Linux distributions. To open a port on UDP, run the following command: <br>
 `sudo iptables -A INPUT -p udp --dport 19132 -j ACCEPT` <br>
 Then, save the firewall with `sudo iptables-save`, and see all open rules with `sudo iptables -L`. <br>
 Further helpful guides for iptables: [DigitalOcean](https://www.digitalocean.com/community/tutorials/how-to-set-up-a-firewall-using-iptables-on-ubuntu-14-04), [Ubuntu](https://help.ubuntu.com/community/IptablesHowTo)
 
-- `firewalld` Add a port on UDP by running <br>
-`sudo firewall-cmd --zone=public --permanent --add-port=19132/udp` <br>
-Then, reload the firewall with `sudo firewall-cmd --reload`, and see all open rules with `sudo firewall-cmd --list-all`. <br>
-Further helpful guides: [DigitalOcean](https://www.digitalocean.com/community/tutorials/how-to-set-up-a-firewall-using-firewalld-on-centos-7)
-
-## Using Docker/Pterodactyl
-In addition to portforwarding the port in your server's firewall (and, if applicable, your router/modem), you will need to assign the port in Docker/Pterodactyl.
+## Using Docker or Pterodactyl
+In addition to port forwarding the port in your server's firewall (and, if applicable, your router/modem), you will need to assign the port in Docker/Pterodactyl.
 
 ### Pterodactyl
-
 Make sure to allocate the port to the server in the Pterodactyl panel, additionally to portforwarding it. See [here](https://pterodactyl.io/community/games/minecraft.html#allocations-in-the-panel) for more information.
 ![Pterodactyl port allocation](https://cdn.discordapp.com/attachments/613194762249437245/1138630494909640794/image.png)
+There are also different Geyser eggs for Pterodactyl, which can be found [here](https://github.com/GeyserMC/pterodactyl-stuff).
 
 <div class="alert alert-warning" role="alert">
     If you are not able to allocate the port in the Pterodactyl panel, you will need to contact your server host to allocate one for you or try to use an existing port allocation.
@@ -66,7 +86,7 @@ ports:
 
 Alternatively, add another port with the `-p 19132:19132/udp` flag to the docker run command.
 
-## OVH/Oracle Cloud/SoYouStart
+## Issues with specific VPS/KVM providers
 Some providers, such as OVH, Oracle Cloud, and SoYouStart, have a firewall that blocks UDP ports by default/in most cases.
 
 ### OVH/SoYouStart

--- a/_docs/geyser/portforwarding.md
+++ b/_docs/geyser/portforwarding.md
@@ -11,7 +11,8 @@ There are also guides for specific configurations, such as Docker/Pterodactyl, o
 </div>
 
 ## Portforwarding on Linux/Windows
-These are (limited) examples of how to open a port under Windows and Linux. Additionally, you will need to portforward the port on your router.
+These are (limited) examples of how to open a port under Windows and Linux. 
+Additionally, you will need to portforward the port on your router/modem - see [here](https://www.howtogeek.com/66214/how-to-forward-ports-on-your-router/) or [here](https://www.lifewire.com/how-to-port-forward-4163829) for helpful guides.
 Additionally, if you do not have a static IP address, your IP address may change over time. 
 
 <div class="alert alert-info" role="alert">
@@ -89,11 +90,15 @@ Alternatively, add another port with the `-p 19132:19132/udp` flag to the docker
 ## Issues with specific VPS/KVM providers
 Some providers, such as OVH, Oracle Cloud, and SoYouStart, have a firewall that blocks UDP ports by default/in most cases.
 
-### OVH/SoYouStart
+### OVH and SoYouStart
 By default, OVHs firewall requires a TCP ping to the server before allowing UDP connections. This is not possible with Geyser, so you will need to disable the firewall.
 
+<div class="alert alert-warning" role="alert">
+    If you do not have access to these firewall settings, but got linked to this page, please contact your server host and provide them with this link - they are likely using OVH internally.	
+</div>
+
 **To verify/temporary work around it:** <br>
-Attempt to connect to the Bedrock IP and port through a web browser - for example, `http://test.geysermc.org:19132`. Connecting won't work, but then try connecting through Bedrock on that same device, and it should work.
+Attempt to connect to your servers IP and port through a web browser - for example, `http://test.geysermc.org:19132`. Connecting won't work, but then try connecting through Bedrock on that same device, and it should work.
 Alternatively, try connecting to the server first on Java edition, then on Bedrock with the same device.
 
 **To resolve it:** <br>
@@ -103,16 +108,12 @@ OVH:
 2. Click on the `...` button on the table for your IP -> then `...` and `Configure the GAME firewall` -> `Add rule` -> `Other protocol` (or `minecraftPocketEdition` if available)
 3. Add your Geyser port into `outgoing port`.
 
-SoYouStart:
+SoYouStart (subsidary of OVH):
 1. Click the IP tab.
 2. Click the gear at the right of the public IP address; select "Game mitigation".
 3. Pick "Add a rule".
 4. Select "minecraftPocketEdition" in the dropdown list and enter the target UDP ports.
 5. Save and wait a few seconds for the changes to come into effect.
-
-<div class="alert alert-warning" role="alert">
-    If you do not have access to these firewall settings, but got linked to this page anyway, please contact your server host - they are likely using OVH internally.	
-</div>
 
 ### Oracle Cloud/OCI
 You'll need to allow port 19132 on UDP in both the security list and the firewall-cmd command.

--- a/_docs/geyser/understanding-the-config.md
+++ b/_docs/geyser/understanding-the-config.md
@@ -91,8 +91,6 @@ saved-user-logins:
 
 **`disable-bedrock-scaffolding`**: Whether Bedrock players are blocked from performing their scaffolding-style bridging.
 
-**`always-quick-change-armor`**: Whether Bedrock players can right-click outside their inventory to replace armor in their inventory, even if the armor slot is already occupied (which Java Edition doesn't allow).
-
 **`emote-offhand-workaround`**: Since Java Edition 1.9, clients have had the ability to switch the item in their mainhand and offhand with a keybind. Bedrock Edition does not have this ability, so this config option makes up for it, If set, when a Bedrock player performs any emote, it will swap the offhand and mainhand items, just like the Java Edition keybind. There are three options this can be set to:
 - `disabled` - the default/fallback, which doesn't apply this workaround
 - `no-emotes` - emotes will NOT be sent to other Bedrock clients and offhand will be swapped. This effectively disables all emotes from being seen.
@@ -120,7 +118,7 @@ saved-user-logins:
 
 **`notify-on-new-bedrock-update`**: Whether to alert the console and operators that a new Geyser version is available that supports a Bedrock version that this Geyser version does not support. It's recommended to keep this option enabled, as many Bedrock platforms auto-update.
 
-**`unusable-space-block`**: Which item to use to mark unavailable slots in a Bedrock player inventory. Examples of this are the 2x2 crafting grid while in creative, or custom inventory menus with sizes different from the usual 3x9. A barrier block is the default item (minecraft:barrier is therefore the default value). Takes any Java Minecraft identifier, e.g. "minecraft:apple".
+**`unusable-space-block`**: Which item to use to mark unavailable slots in a Bedrock player inventory. Examples of this are the 2x2 crafting grid while in creative, or custom inventory menus with sizes different from the usual 3x9. A barrier block is the default item (minecraft:barrier is therefore the default value). Takes any Minecraft Bedrock identifier, e.g. `minecraft:apple`. To set this to a custom item, you will need to add the `geyser_custom:` namespace.
 
 ## Metrics
 

--- a/_docs/other/hurricane.md
+++ b/_docs/other/hurricane.md
@@ -13,13 +13,13 @@ Issues with each workaround are listed in the plugin's config. **Please take you
 - https://github.com/GeyserMC/Geyser/issues/638 by implementing the control server-side.
 
 Supported Versions:
-- 1.14.x - 1.19.x
+- 1.14.x - 1.20.x
 - 1.17.x & above for pig riding
 
 ### Download
-Spigot/Paper: [GitHub releases](https://github.com/GeyserMC/Hurricane/) 
+Spigot/Paper: [GitHub releases](https://github.com/GeyserMC/Hurricane/) <br>
 Fabric: [Modrinth](https://modrinth.com/mod/hurricane)
 
 ### Source
-Main: [GeyserMC/Hurricane](https://github.com/GeyserMC/Hurricane)
+Main: [GeyserMC/Hurricane](https://github.com/GeyserMC/Hurricane) <br>
 Unofficial fabric fork: [onebeastchris/Hurricane-fabric](https://github.com/onebeastchris/hurricane-fabric)

--- a/_includes/setup/instructions/geyser/selfhost/fabric.md
+++ b/_includes/setup/instructions/geyser/selfhost/fabric.md
@@ -37,8 +37,8 @@ To use Geyser on an older Fabric server, you can use Geyser on a BungeeCord/Velo
    To achieve that, you have two options: <br>
 
     - Portforwarding: Open the Geyser port (e.g. 19132) on the UDP protocol in your router/modem, and in the Windows/Linux firewall.
-      After doing this, players can connect with your public IPv4 + port to your server. 
-      See [here](https://www.lifewire.com/how-to-port-forward-4163829) for a helpful guide. <br>
+      [Our portforwarding guide](/geyser/portforwarding) explains how to do this in detail.
+      Then, players can connect with your public IPv4 + port to your server. <br>
 
     - playit.gg: Instead of opening a port (which might not be an option/if you do not want to expose your home ip), you can use
       the playit.gg service to create a tunnel for you to route the traffic through. See our [playit.gg guide](/geyser/playit-gg).

--- a/_includes/setup/instructions/geyser/selfhost/proxy.md
+++ b/_includes/setup/instructions/geyser/selfhost/proxy.md
@@ -39,8 +39,8 @@
     To achieve that, you have two options: <br>
 
     - Portforwarding: Open the Geyser port (e.g. 19132) on the UDP protocol in your router/modem, and in the Windows/Linux firewall.
-   After doing this, players can connect with your public IPv4 + port to your server.
-   See [here](https://www.lifewire.com/how-to-port-forward-4163829) for a helpful guide. <br>
+   [Our portforwarding guide](/geyser/portforwarding) explains how to do this in detail.
+   Then, players can connect with your public IPv4 + port to your server. <br>
 
     - playit.gg: Instead of opening a port (which might not be an option/if you do not want to expose your home ip), you can use
    the playit.gg service to create a tunnel for you to route the traffic through. See our [playit.gg guide](/geyser/playit-gg).

--- a/_includes/setup/instructions/geyser/selfhost/spigot.md
+++ b/_includes/setup/instructions/geyser/selfhost/spigot.md
@@ -36,9 +36,9 @@
     You will need to expose the port Geyser runs on to the Internet if you want players from outside your network to join.
     To achieve that, you have two options: <br>
 
-    - Portforwarding: Open the Geyser port (e.g. 19132) on the UDP protocol in your router/modem, and in the Windows/Linux firewall.
-   After doing this, players can connect with your public IPv4 + port to your server.
-   See [here](https://www.lifewire.com/how-to-port-forward-4163829) for a helpful guide. <br>
+    - Portforwarding: Open the Geyser port (e.g. 19132) on the UDP protocol in your router/modem, and in the Windows/Linux firewall. 
+   [Our portforwarding guide](/geyser/portforwarding) explains how to do this in detail.
+   After doing this, players can connect with your public IPv4 + port to your server. <br>
 
     - playit.gg: Instead of opening a port (which might not be an option/if you do not want to expose your home ip), you can use
    the playit.gg service to create a tunnel for you to route the traffic through. See our [playit.gg guide](/geyser/playit-gg).

--- a/_includes/setup/instructions/geyser/selfhost/standalone.md
+++ b/_includes/setup/instructions/geyser/selfhost/standalone.md
@@ -4,6 +4,12 @@
    You need to have Java 16 or higher installed to run Geyser. To run Geyser Standalone on Android or iOS, see the bottom of this page.
 </div>
 
+<div class="alert alert-warning" role="alert">
+   Geyser-Standalone is NOT a plugin or mod! It is a standalone Java program that you would run separately to your Java Edition server.
+</div>
+
+# General Setup & Configuration
+
 1. Download Geyser Standalone from [here](https://download.geysermc.org/v2/projects/geyser/versions/latest/builds/latest/downloads/standalone).
 2. Create a new folder for Geyser, and drop the jar in there.
 3. Start Geyser Standalone:
@@ -59,7 +65,7 @@ set it to either `online` for an online mode server, or `offline` for an offline
 
     - Portforwarding: Open the Geyser port (e.g. 19132) on the UDP protocol in your router/modem, and in the Windows/Linux firewall.
       After doing this, players can connect with your public IPv4 + port to your server.
-      See [here](https://www.lifewire.com/how-to-port-forward-4163829) for a helpful guide. <br>
+      See [here](/geyser/portforwarding/) for a helpful guide. <br>
 
     - playit.gg: Instead of opening a port (which might not be an option/if you do not want to expose your home ip), you can use
       the playit.gg service to create a tunnel for you to route the traffic through. See our [playit.gg guide](/geyser/playit-gg).


### PR DESCRIPTION
Changes:
- add a portforwarding page, with info on ovh/oracle cloud, or ptero/docker
- minor tweaks
- yeet some stuff from common issues
- yeet dead providers, add more templates
- yeet google/hetzner (not dedicated mc hosters) from the providers list
 -> rfc: should oci/oracle/ovh be kept there for the special issues? Or is mentioning them on the portforwarding guide enough?
 
 