### PR TITLE
Update providers.json

### DIFF
--- a/_data/providers.json
+++ b/_data/providers.json
@@ -29,7 +29,7 @@
     {
       "name": "Cubes Hosting",
       "url": "https://www.cubes.host/",
-      "description": "Order a Minecraft Cross-Play (GeyserMC) plan and directly have access to a paper server with GeyserMC pre-installed. Geyser-Standalone can be set up through a support ticket."
+      "description": "Order a Minecraft Cross-Play (GeyserMC) plan and directly have access to a paper server with GeyserMC pre-installed. Configure the second port in the GeyserMC config that came with the service and restart the service. Now you can connect through both the Java and Bedrock Editions of Minecraft. Geyser-Standalone can be set up through a support ticket"
     },
     {
       "name": "exaroton",
@@ -49,7 +49,7 @@
     {
       "name": "Minecraft Host",
       "url": "https://minecraft-host.com/",
-      "description": "Order a Minecraft Cross-Play (GeyserMC) plan and directly have access to a paper server with GeyserMC pre-installed. Geyser-Standalone can be set up through a support ticket."
+      "description": "Order a Minecraft Cross-Play (GeyserMC) plan and directly have access to a paper server with GeyserMC pre-installed. Configure the second port in the GeyserMC config that came with the service and restart the service. Now you can connect through both the Java and Bedrock Editions of Minecraft. Geyser-Standalone can be set up through a support ticket"
     },
     {
       "name": "Minefort",

--- a/_data/providers.json
+++ b/_data/providers.json
@@ -29,7 +29,7 @@
     {
       "name": "Cubes Hosting",
       "url": "https://www.cubes.host/",
-      "description": "Install Geyser using the plugin manager. Then restart the server and Geyser will run on an additional port - you can check it in the server console. Geyser-Standalone can be set up through a support ticket."
+      "description": "Order a Minecraft Cross-Play (GeyserMC) plan and directly have access to a paper server with GeyserMC pre-installed. Geyser-Standalone can be set up through a support ticket."
     },
     {
       "name": "exaroton",
@@ -45,6 +45,11 @@
       "name": "MCProHosting",
       "url": "https://mcprohosting.com/",
       "description": "Click 'Enable Bedrock Support' on the server dashboard and follow the steps. For manual installation: Add 'Destination Port' `19132` with 'Protocol UDP' to the port forward mapping and connect to the given source port."
+    },
+    {
+      "name": "Minecraft Host",
+      "url": "https://minecraft-host.com/",
+      "description": "Order a Minecraft Cross-Play (GeyserMC) plan and directly have access to a paper server with GeyserMC pre-installed. Geyser-Standalone can be set up through a support ticket."
     },
     {
       "name": "Minefort",
@@ -65,11 +70,6 @@
       "name": "OMGServ",
       "url": "https://www.omgserv.com/en/",
       "description": "Select Geyser in the [Install Menu](https://i.imgur.com/Gewpsrq.png), it will be automatically installed. You can enable floodgate in the [server properties on the dashboard](https://i.imgur.com/jg5mzNj.png)."
-    },
-    {
-      "name": "PloudOS",
-      "url": "https://ploudos.com/",
-      "description": "Connect via `geyser.ploudos.com` and enter the with your Java IP and port. See [PloudOS's article](https://ploudos.com/faq/#How-do-I-connect-from-Bedrock-to-a-Java-server) for more details."
     },
     {
       "name": "Pufferfish Host",
@@ -207,12 +207,6 @@
       "name": "Fusion Hosting",
       "url": "https://fusionhostingltd.co.uk",
       "description": "Get Geyser as a plugin. Use the same port as your Java server for the Bedrock port in your config (either by setting it yourself, or enabling “clone-remote-port”) and connect with the same IP and port as you would on Java or create a port in the Network tab on the panel & use this for Geyser."
-    },
-    {
-      "name": "Futurehosting",
-      "url": "https://futurehosting.org/",
-      "description_template": "default",
-      "description": "Make sure your `bedrock` `address` in your Geyser config is your server IP."
     },
     {
       "name": "GameHosting.it",
@@ -359,11 +353,6 @@
       "name": "Sparked Host",
       "url": "https://sparkedhost.com",
       "description_template": "default"
-    },
-    {
-      "name": "StellaNode",
-      "url": "https://stellanode.com/",
-      "description": "Open a support ticket on the billing panel to receive an additional UDP port for Geyser, then set that as the `bedrock port`."
     },
     {
       "name": "STIPE",


### PR DESCRIPTION
Updated Cubes Hosting, Added Minecraft-Host

Removed PloudOS it has stopped offering services and should therefor be removed. Same for FutureHosting which seems to be offline, Same for Stellanode (aka Plasmanode) which seems to be offline