### PR TITLE
docs: replace uuid.kejona.dev with mcprofile.io

### DIFF
--- a/_data/faq.yml
+++ b/_data/faq.yml
@@ -101,7 +101,7 @@
 
     - title: How do I find a player's UUID without them joining when using Floodgate?
       content: |
-        Use [this page.](https://uuid.kejona.dev/) If this doesn't work, then try this method:
+        Use [this page.](https://mcprofile.io/) If this doesn't work, then try this method:
         
         First, you'll need to get the XUID of the player. There are several third-party websites to find this, for example, [this one](https://cxkes.me/xbox/xuid) (unaffiliated with Geyser). Make sure to choose "Hexidecimal." You'll need to enter the player's Xbox Gamertag, and, once submitted, it should display the XUID in the format of `xxxxxxxxxxxxxxxx`. To turn the XUID into a UUID that Java Edition can recognize, you need to put the XUID in this format: `00000000-0000-0000-xxxx-xxxxxxxxxxxx`. If formatted right, Java Edition should accept it as a UUID.
 

--- a/_data/faq.yml
+++ b/_data/faq.yml
@@ -101,6 +101,8 @@
 
     - title: How do I find a player's UUID without them joining when using Floodgate?
       content: |
+        Use [this page.](https://uuid.kejona.dev/) If this doesn't work, then try this method:
+        
         First, you'll need to get the XUID of the player. There are several third-party websites to find this, for example, [this one](https://cxkes.me/xbox/xuid) (unaffiliated with Geyser). Make sure to choose "Hexidecimal." You'll need to enter the player's Xbox Gamertag, and, once submitted, it should display the XUID in the format of `xxxxxxxxxxxxxxxx`. To turn the XUID into a UUID that Java Edition can recognize, you need to put the XUID in this format: `00000000-0000-0000-xxxx-xxxxxxxxxxxx`. If formatted right, Java Edition should accept it as a UUID.
 
     - title: Can I remove the prefix of Floodgate players?

--- a/_data/faq.yml
+++ b/_data/faq.yml
@@ -101,8 +101,6 @@
 
     - title: How do I find a player's UUID without them joining when using Floodgate?
       content: |
-        Use [this page.](https://uuid.kejona.dev/) If this doesn't work, then try this method:
-        
         First, you'll need to get the XUID of the player. There are several third-party websites to find this, for example, [this one](https://cxkes.me/xbox/xuid) (unaffiliated with Geyser). Make sure to choose "Hexidecimal." You'll need to enter the player's Xbox Gamertag, and, once submitted, it should display the XUID in the format of `xxxxxxxxxxxxxxxx`. To turn the XUID into a UUID that Java Edition can recognize, you need to put the XUID in this format: `00000000-0000-0000-xxxx-xxxxxxxxxxxx`. If formatted right, Java Edition should accept it as a UUID.
 
     - title: Can I remove the prefix of Floodgate players?

--- a/_docs/floodgate/faq.md
+++ b/_docs/floodgate/faq.md
@@ -13,7 +13,7 @@ In your Floodgate config, change `username-prefix` to whichever prefix you desir
 On some older Paper servers (or any forks that use them), you may need to also shut down your server and delete your `usercache.json` file located in the same folder as your server jar to prevent users who already joined from having the old prefix. See [this issue](/floodgate/issues/#prefix-is-not-changing-on-the-server-after-changing-it-in-the-config) for more information.
 
 ## Obtaining UUIDs for Floodgate players
-Check your server logs, or use [this](https://uuid.kejona.dev/) page. If this doesn't work, then try this method:
+Check your server logs, or use [this](https://mcprofile.io/) page. If this doesn't work, then try this method:
 
 First, you'll need to get the XUID of the player. There are several third-party websites to find this, for example, [this one](https://www.cxkes.me/xbox/xuid) (unaffiliated with Geyser). Make sure to choose "Hexidecimal." You'll need to enter the player's Xbox Gamertag, and, once submitted, and it should display the XUID in the format of `xxxxxxxxxxxxxxxx`. To turn the XUID into a UUID that Java Edition can recognize, you need to put the XUID in this format: `00000000-0000-0000-xxxx-xxxxxxxxxxxx`. If formatted right, Java Edition should accept it as a UUID.
 

--- a/_docs/floodgate/faq.md
+++ b/_docs/floodgate/faq.md
@@ -13,7 +13,7 @@ In your Floodgate config, change `username-prefix` to whichever prefix you desir
 On some older Paper servers (or any forks that use them), you may need to also shut down your server and delete your `usercache.json` file located in the same folder as your server jar to prevent users who already joined from having the old prefix. See [this issue](/floodgate/issues/#prefix-is-not-changing-on-the-server-after-changing-it-in-the-config) for more information.
 
 ## Obtaining UUIDs for Floodgate players
-Check your server logs, or use [this](https://uuid.kejona.dev/) page. If this doesn't work, then try this method:
+Check your server logs. If this doesn't work, then try this method:
 
 First, you'll need to get the XUID of the player. There are several third-party websites to find this, for example, [this one](https://www.cxkes.me/xbox/xuid) (unaffiliated with Geyser). Make sure to choose "Hexidecimal." You'll need to enter the player's Xbox Gamertag, and, once submitted, and it should display the XUID in the format of `xxxxxxxxxxxxxxxx`. To turn the XUID into a UUID that Java Edition can recognize, you need to put the XUID in this format: `00000000-0000-0000-xxxx-xxxxxxxxxxxx`. If formatted right, Java Edition should accept it as a UUID.
 

--- a/_docs/floodgate/faq.md
+++ b/_docs/floodgate/faq.md
@@ -13,7 +13,7 @@ In your Floodgate config, change `username-prefix` to whichever prefix you desir
 On some older Paper servers (or any forks that use them), you may need to also shut down your server and delete your `usercache.json` file located in the same folder as your server jar to prevent users who already joined from having the old prefix. See [this issue](/floodgate/issues/#prefix-is-not-changing-on-the-server-after-changing-it-in-the-config) for more information.
 
 ## Obtaining UUIDs for Floodgate players
-Check your server logs. If this doesn't work, then try this method:
+Check your server logs, or use [this](https://uuid.kejona.dev/) page. If this doesn't work, then try this method:
 
 First, you'll need to get the XUID of the player. There are several third-party websites to find this, for example, [this one](https://www.cxkes.me/xbox/xuid) (unaffiliated with Geyser). Make sure to choose "Hexidecimal." You'll need to enter the player's Xbox Gamertag, and, once submitted, and it should display the XUID in the format of `xxxxxxxxxxxxxxxx`. To turn the XUID into a UUID that Java Edition can recognize, you need to put the XUID in this format: `00000000-0000-0000-xxxx-xxxxxxxxxxxx`. If formatted right, Java Edition should accept it as a UUID.
 


### PR DESCRIPTION
The URL only redirects to a broken `ww1` subdomain or malware websites.