### PR TITLE
Add advisory regarding OVH Game DDoS incompatibility

### DIFF
--- a/_docs/geyser/port-forwarding.md
+++ b/_docs/geyser/port-forwarding.md
@@ -126,7 +126,6 @@ OVH:
 2. Click on the `...` button on the table for your IP -> then `...` and `Configure the GAME firewall` -> `Add rule` -> `Other protocol` ~~(or `minecraftPocketEdition` if available)~~
 3. Add your Geyser port into `outgoing port`.
 
-
 SoYouStart (subsidiary of OVH):
 1. Click the IP tab.
 2. Click the gear at the right of the public IP address; select "Game mitigation".

--- a/_docs/geyser/port-forwarding.md
+++ b/_docs/geyser/port-forwarding.md
@@ -136,7 +136,7 @@ SoYouStart (subsidiary of OVH):
 #### OVH/SoYouStart Filter Incompatibility Issue
 The `minecraftPocketEdition` rule/filter/game type currently does not work and you must use the `Other` type.  
 
-If you would like to continue using `minecraftPocketEdition`, you may disable the incompatible security feature by adding `-DGeyser.RakSendCookie=false` to your startup flags for Geyser (works regardless of whether you use plugin or standalone Geyser).
+If you would like to continue using the filter type `minecraftPocketEdition`, you may disable the incompatible security feature by adding `-DGeyser.RakSendCookie=false` to your Java server's (or Geyser Standalone proxy's) startup flags.
 
 For more information see:  
     [This issue on OVH's infrastructure roadmap](https://github.com/ovh/infrastructure-roadmap/issues/186)  

--- a/_docs/geyser/port-forwarding.md
+++ b/_docs/geyser/port-forwarding.md
@@ -133,8 +133,8 @@ SoYouStart (subsidiary of OVH):
 4. Select "minecraftPocketEdition" in the dropdown list and enter the target UDP ports.
 5. Save and wait a few seconds for the changes to come into effect.
 
-#### OVH/SoYouStart Filter Incompatibility Issue
-The `minecraftPocketEdition` rule/filter/game type currently does not work and you must use the `Other` type.  
+#### OVH/SoYouStart Game Firewall Incompatibility Issue
+The OVH GAME filter type `minecraftPocketEdition` currently does not work and you must use the `Other` type.  
 
 If you would like to continue using the filter type `minecraftPocketEdition`, you may disable the incompatible security feature by adding `-DGeyser.RakSendCookie=false` to your Java server's (or Geyser Standalone proxy's) startup flags.
 

--- a/_docs/geyser/port-forwarding.md
+++ b/_docs/geyser/port-forwarding.md
@@ -139,8 +139,8 @@ The `minecraftPocketEdition` rule/filter/game type currently does not work and y
 If you would like to continue using the filter type `minecraftPocketEdition`, you may disable the incompatible security feature by adding `-DGeyser.RakSendCookie=false` to your Java server's (or Geyser Standalone proxy's) startup flags.
 
 For more information see:  
-    [This issue on OVH's infrastructure roadmap](https://github.com/ovh/infrastructure-roadmap/issues/186)  
-    [The pull request which implemented the security feature that caused the incompatibility](https://github.com/GeyserMC/Geyser/pull/4554)
+ - [This issue on OVH's infrastructure roadmap](https://github.com/ovh/infrastructure-roadmap/issues/186)  
+ - [The pull request which implemented the security feature that caused the incompatibility](https://github.com/GeyserMC/Geyser/pull/4554)
 
 ### Oracle Cloud/OCI
 By default, Oracle Cloud will block all incoming traffic except for SSH and RDP. This must be resolved within Oracle Cloud itself and the Compute Instance running Geyser.

--- a/_docs/geyser/port-forwarding.md
+++ b/_docs/geyser/port-forwarding.md
@@ -123,8 +123,9 @@ Alternatively, try connecting to the server first on Java edition, then on Bedro
 
 OVH:
 1. Navigate to `Network interfaces`
-2. Click on the `...` button on the table for your IP -> then `...` and `Configure the GAME firewall` -> `Add rule` -> `Other protocol` (or `minecraftPocketEdition` if available)
+2. Click on the `...` button on the table for your IP -> then `...` and `Configure the GAME firewall` -> `Add rule` -> `Other protocol` ~~(or `minecraftPocketEdition` if available)~~
 3. Add your Geyser port into `outgoing port`.
+
 
 SoYouStart (subsidiary of OVH):
 1. Click the IP tab.
@@ -132,6 +133,15 @@ SoYouStart (subsidiary of OVH):
 3. Pick "Add a rule".
 4. Select "minecraftPocketEdition" in the dropdown list and enter the target UDP ports.
 5. Save and wait a few seconds for the changes to come into effect.
+
+#### OVH/SoYouStart Filter Incompatibility Issue
+The `minecraftPocketEdition` rule/filter/game type currently does not work and you must use the `Other` type.  
+
+If you would like to continue using `minecraftPocketEdition`, you may disable the incompatible security feature by adding `-DGeyser.RakSendCookie=false` to your startup flags for Geyser (works regardless of whether you use plugin or standalone Geyser).
+
+For more information see:  
+    [This issue on OVH's infrastructure roadmap](https://github.com/ovh/infrastructure-roadmap/issues/186)  
+    [The pull request which implemented the security feature that caused the incompatibility](https://github.com/GeyserMC/Geyser/pull/4554)
 
 ### Oracle Cloud/OCI
 By default, Oracle Cloud will block all incoming traffic except for SSH and RDP. This must be resolved within Oracle Cloud itself and the Compute Instance running Geyser.


### PR DESCRIPTION
Title. 

If and when OVH resolves this, the advisory can and should be removed as the use of the `minecraftPocketEdition` is advisable over the more permissive `Other` filter.

Related/relevant:
https://github.com/ovh/infrastructure-roadmap/issues/186
https://github.com/GeyserMC/Geyser/pull/4554